### PR TITLE
fix: correct flag parsing for comma-separated namespace and resource …

### DIFF
--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -28,6 +28,9 @@ func main() {
     
     flag.Parse() // Parse flags after they've been added to flag.CommandLine
     
+    // Parse the comma-separated string flags after flag.Parse()
+    config.ParseStringFlags()
+    
     // Set default parallelism if not specified
     if config.Parallelism == 0 {
         config.Parallelism = runtime.NumCPU()

--- a/pkg/janitor/config.go
+++ b/pkg/janitor/config.go
@@ -34,6 +34,12 @@ type Config struct {
 	LogFormat             string
 	Parallelism           int
 
+	// Internal string fields for flag parsing
+	includeResourcesStr   string
+	excludeResourcesStr   string
+	includeNamespacesStr  string
+	excludeNamespacesStr  string
+
 	// Additional configuration
 	Rules               []Rule
 	ResourceContextHook ResourceContextHook
@@ -64,24 +70,25 @@ func (c *Config) AddFlags(fs *flag.FlagSet) {
 	fs.IntVar(&c.DeleteNotification, "delete-notification", 0, "Send an event seconds before to warn of the deletion")
 	
 	// Use custom variables to handle comma-separated lists
-	var includeResources, excludeResources, includeNamespaces, excludeNamespaces string
-	fs.StringVar(&includeResources, "include-resources", getEnvOrDefault("INCLUDE_RESOURCES", "all"), "Resources to consider for clean up (comma-separated)")
-	fs.StringVar(&excludeResources, "exclude-resources", getEnvOrDefault("EXCLUDE_RESOURCES", defaultExcludeResources), "Resources to exclude from clean up (comma-separated)")
-	fs.StringVar(&includeNamespaces, "include-namespaces", getEnvOrDefault("INCLUDE_NAMESPACES", "all"), "Include namespaces for clean up (comma-separated)")
-	fs.StringVar(&excludeNamespaces, "exclude-namespaces", getEnvOrDefault("EXCLUDE_NAMESPACES", defaultExcludeNamespaces), "Exclude namespaces from clean up (comma-separated)")
+	fs.StringVar(&c.includeResourcesStr, "include-resources", getEnvOrDefault("INCLUDE_RESOURCES", "all"), "Resources to consider for clean up (comma-separated)")
+	fs.StringVar(&c.excludeResourcesStr, "exclude-resources", getEnvOrDefault("EXCLUDE_RESOURCES", defaultExcludeResources), "Resources to exclude from clean up (comma-separated)")
+	fs.StringVar(&c.includeNamespacesStr, "include-namespaces", getEnvOrDefault("INCLUDE_NAMESPACES", "all"), "Include namespaces for clean up (comma-separated)")
+	fs.StringVar(&c.excludeNamespacesStr, "exclude-namespaces", getEnvOrDefault("EXCLUDE_NAMESPACES", defaultExcludeNamespaces), "Exclude namespaces from clean up (comma-separated)")
 	
 	fs.StringVar(&c.RulesFile, "rules-file", os.Getenv("RULES_FILE"), "Load TTL rules from given file path")
 	fs.StringVar(&c.DeploymentTimeAnnotation, "deployment-time-annotation", "", "Annotation that contains a resource's last deployment time")
 	fs.BoolVar(&c.IncludeClusterResources, "include-cluster-resources", false, "Include cluster scoped resources")
 	fs.StringVar(&c.LogFormat, "log-format", defaultLogFormat, "Set custom log format")
 	fs.IntVar(&c.Parallelism, "parallelism", DefaultParallelism, "Number of parallel workers for resource processing (0 = use number of CPUs)")
+}
 
-	// We'll parse the flags in main.go, not here
-	
-	c.IncludeResources = strings.Split(includeResources, ",")
-	c.ExcludeResources = strings.Split(excludeResources, ",")
-	c.IncludeNamespaces = strings.Split(includeNamespaces, ",")
-	c.ExcludeNamespaces = strings.Split(excludeNamespaces, ",")
+// ParseStringFlags parses the comma-separated string flags into string slices
+// This must be called after flag.Parse()
+func (c *Config) ParseStringFlags() {
+	c.IncludeResources = strings.Split(c.includeResourcesStr, ",")
+	c.ExcludeResources = strings.Split(c.excludeResourcesStr, ",")
+	c.IncludeNamespaces = strings.Split(c.includeNamespacesStr, ",")
+	c.ExcludeNamespaces = strings.Split(c.excludeNamespacesStr, ",")
 }
 
 // Validate checks if the configuration is valid

--- a/pkg/janitor/config_test.go
+++ b/pkg/janitor/config_test.go
@@ -1,0 +1,310 @@
+package janitor
+
+import (
+	"context"
+	"flag"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestConfigFlagParsing(t *testing.T) {
+	tests := []struct {
+		name                  string
+		args                  []string
+		expectedIncludeResources []string
+		expectedExcludeResources []string
+		expectedIncludeNamespaces []string
+		expectedExcludeNamespaces []string
+	}{
+		{
+			name: "default flags",
+			args: []string{},
+			expectedIncludeResources: []string{"all"},
+			expectedExcludeResources: []string{"events", "controllerrevisions"},
+			expectedIncludeNamespaces: []string{"all"},
+			expectedExcludeNamespaces: []string{"kube-system"},
+		},
+		{
+			name: "custom include resources",
+			args: []string{"-include-resources", "pods,services"},
+			expectedIncludeResources: []string{"pods", "services"},
+			expectedExcludeResources: []string{"events", "controllerrevisions"},
+			expectedIncludeNamespaces: []string{"all"},
+			expectedExcludeNamespaces: []string{"kube-system"},
+		},
+		{
+			name: "custom include namespaces",
+			args: []string{"-include-namespaces", "default,test"},
+			expectedIncludeResources: []string{"all"},
+			expectedExcludeResources: []string{"events", "controllerrevisions"},
+			expectedIncludeNamespaces: []string{"default", "test"},
+			expectedExcludeNamespaces: []string{"kube-system"},
+		},
+		{
+			name: "custom exclude namespaces",
+			args: []string{"-exclude-namespaces", "kube-system,kube-public"},
+			expectedIncludeResources: []string{"all"},
+			expectedExcludeResources: []string{"events", "controllerrevisions"},
+			expectedIncludeNamespaces: []string{"all"},
+			expectedExcludeNamespaces: []string{"kube-system", "kube-public"},
+		},
+		{
+			name: "single namespace include",
+			args: []string{"-include-namespaces", "test-namespace"},
+			expectedIncludeResources: []string{"all"},
+			expectedExcludeResources: []string{"events", "controllerrevisions"},
+			expectedIncludeNamespaces: []string{"test-namespace"},
+			expectedExcludeNamespaces: []string{"kube-system"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a new FlagSet for this test
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			
+			// Create config and add flags
+			config := NewConfig()
+			config.AddFlags(fs)
+
+			// Parse the test arguments
+			if len(tt.args) > 0 {
+				err := fs.Parse(tt.args)
+				if err != nil {
+					t.Fatalf("Failed to parse flags: %v", err)
+				}
+			}
+
+			// Parse the string flags after flag parsing
+			config.ParseStringFlags()
+
+			// Check include resources
+			if len(config.IncludeResources) != len(tt.expectedIncludeResources) {
+				t.Errorf("Expected %d include resources, got %d", len(tt.expectedIncludeResources), len(config.IncludeResources))
+			}
+			for i, expected := range tt.expectedIncludeResources {
+				if i >= len(config.IncludeResources) || config.IncludeResources[i] != expected {
+					t.Errorf("Expected include resource %d to be %s, got %s", i, expected, config.IncludeResources[i])
+				}
+			}
+
+			// Check exclude resources
+			if len(config.ExcludeResources) != len(tt.expectedExcludeResources) {
+				t.Errorf("Expected %d exclude resources, got %d", len(tt.expectedExcludeResources), len(config.ExcludeResources))
+			}
+			for i, expected := range tt.expectedExcludeResources {
+				if i >= len(config.ExcludeResources) || config.ExcludeResources[i] != expected {
+					t.Errorf("Expected exclude resource %d to be %s, got %s", i, expected, config.ExcludeResources[i])
+				}
+			}
+
+			// Check include namespaces
+			if len(config.IncludeNamespaces) != len(tt.expectedIncludeNamespaces) {
+				t.Errorf("Expected %d include namespaces, got %d", len(tt.expectedIncludeNamespaces), len(config.IncludeNamespaces))
+			}
+			for i, expected := range tt.expectedIncludeNamespaces {
+				if i >= len(config.IncludeNamespaces) || config.IncludeNamespaces[i] != expected {
+					t.Errorf("Expected include namespace %d to be %s, got %s", i, expected, config.IncludeNamespaces[i])
+				}
+			}
+
+			// Check exclude namespaces
+			if len(config.ExcludeNamespaces) != len(tt.expectedExcludeNamespaces) {
+				t.Errorf("Expected %d exclude namespaces, got %d", len(tt.expectedExcludeNamespaces), len(config.ExcludeNamespaces))
+			}
+			for i, expected := range tt.expectedExcludeNamespaces {
+				if i >= len(config.ExcludeNamespaces) || config.ExcludeNamespaces[i] != expected {
+					t.Errorf("Expected exclude namespace %d to be %s, got %s", i, expected, config.ExcludeNamespaces[i])
+				}
+			}
+		})
+	}
+}
+
+func TestNamespaceCleanupWithTTL(t *testing.T) {
+	tests := []struct {
+		name                  string
+		includeNamespaces     []string
+		excludeNamespaces     []string
+		includeResources      []string
+		namespaces            []corev1.Namespace
+		expectProcessed       []string
+		expectSkipped         []string
+	}{
+		{
+			name:              "specific namespace with TTL",
+			includeNamespaces: []string{"test-namespace"},
+			excludeNamespaces: []string{"kube-system"},
+			includeResources:  []string{"namespaces"},
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-namespace",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "other-namespace",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+			},
+			expectProcessed: []string{"test-namespace"},
+			expectSkipped:   []string{"other-namespace"},
+		},
+		{
+			name:              "all namespaces with TTL",
+			includeNamespaces: []string{"all"},
+			excludeNamespaces: []string{"kube-system"},
+			includeResources:  []string{"namespaces"},
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-namespace",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "another-namespace",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "kube-system",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+			},
+			expectProcessed: []string{"test-namespace", "another-namespace"},
+			expectSkipped:   []string{"kube-system"},
+		},
+		{
+			name:              "exclude specific namespace",
+			includeNamespaces: []string{"all"},
+			excludeNamespaces: []string{"kube-system", "production"},
+			includeResources:  []string{"namespaces"},
+			namespaces: []corev1.Namespace{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-namespace",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "production",
+						CreationTimestamp: metav1.Time{
+							Time: time.Now().Add(-3 * time.Hour),
+						},
+						Annotations: map[string]string{
+							TTLAnnotation: "2h",
+						},
+					},
+				},
+			},
+			expectProcessed: []string{"test-namespace"},
+			expectSkipped:   []string{"production"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create fake clientset
+			clientset := fake.NewSimpleClientset()
+			
+			// Create test namespaces
+			for _, ns := range tt.namespaces {
+				_, err := clientset.CoreV1().Namespaces().Create(context.Background(), &ns, metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("Failed to create namespace %s: %v", ns.Name, err)
+				}
+			}
+
+			// Create janitor with specific config
+			config := &Config{
+				IncludeNamespaces: tt.includeNamespaces,
+				ExcludeNamespaces: tt.excludeNamespaces,
+				IncludeResources:  tt.includeResources,
+				DryRun:            true,
+				Parallelism:       1,
+			}
+
+			j := &Janitor{
+				client: clientset,
+				config: config,
+				cache:  make(map[string]interface{}),
+			}
+
+			// Track which namespaces were processed by checking the matchesResourceFilter
+			for _, ns := range tt.namespaces {
+				// Create an unstructured object to mimic how namespace objects are handled in the real code
+				nsUnstructured := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Namespace",
+						"metadata": map[string]interface{}{
+							"name":              ns.Name,
+							"creationTimestamp": ns.CreationTimestamp.Time.Format(time.RFC3339),
+							"annotations":       ns.Annotations,
+						},
+					},
+				}
+				matches := j.matchesResourceFilter(nsUnstructured)
+				
+				expectedProcessed := false
+				for _, expected := range tt.expectProcessed {
+					if ns.Name == expected {
+						expectedProcessed = true
+						break
+					}
+				}
+				
+				if matches != expectedProcessed {
+					if expectedProcessed {
+						t.Errorf("Expected namespace %s to be processed, but it was not", ns.Name)
+					} else {
+						t.Errorf("Expected namespace %s to be skipped, but it was processed", ns.Name)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
…filters

The comma-separated flags (--include-namespaces, --exclude-namespaces,
  --include-resources, --exclude-resources) were being parsed before
  flag.Parse() was called, causing them to use default values instead
  of user-provided values. This prevented namespaces with TTL
annotations
  from being properly discovered and cleaned up when specific namespace
  filters were provided.

  Changes:
  - Add internal string fields to Config struct for flag parsing
  - Move comma-separated string parsing to ParseStringFlags() method
  - Call ParseStringFlags() after flag.Parse() in main.go
  - Add comprehensive tests for flag parsing and namespace cleanup

  Fixes namespace cleanup when using --include-namespaces flag with
  janitor/ttl annotations.