### PR TITLE
Accept cluster connections instead of building them

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -42,6 +42,12 @@ looked up in the cluster, such as whether a volume claim is mounted. Rules may
 test it.
 _Avoid_: Metadata, enrichment, extra data
 
+**Cluster**:
+The connections one run works through: the typed client for the built-in kinds
+Resource context and events need, and the dynamic client for the arbitrary kinds
+a run lists and deletes. Both are resolved from one set of credentials.
+_Avoid_: Client, clientset, connection pool
+
 **Notification**:
 A warning that a Target is about to be deleted, sent ahead of its Deadline.
 _Avoid_: Alert, message, event (a Notification may be recorded as a Kubernetes
@@ -63,3 +69,9 @@ _Avoid_: Execute, enact, perform, handle
 The module that decides which resources a run considers at all, from the
 configured resource and namespace include and exclude lists.
 _Avoid_: Filter, matcher, scope
+
+**Connect**:
+The module that resolves the ambient credentials and returns the Cluster they
+grant. A run is handed a Cluster and never builds one, so the whole of a run can
+be exercised against fakes.
+_Avoid_: Client factory, bootstrap, initialise

--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -72,10 +72,12 @@ func main() {
 		log.Fatalf("Failed to load rules: %v", err)
 	}
 
-	j, err := janitor.New(config)
+	cluster, err := janitor.Connect()
 	if err != nil {
-		log.Fatalf("Failed to create janitor: %v", err)
+		log.Fatalf("Failed to connect to cluster: %v", err)
 	}
+
+	j := janitor.New(config, cluster)
 
 	// Set up context with cancellation and signal handling
 	ctx, gs := shutdown.ShutdownWithContext()

--- a/pkg/janitor/cluster.go
+++ b/pkg/janitor/cluster.go
@@ -1,0 +1,65 @@
+package janitor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// Cluster is the pair of connections a run works through: the typed client for
+// the built-in kinds Resource context and events need, and the dynamic client
+// for the arbitrary kinds a run lists and deletes. A Janitor is handed one; it
+// never builds its own.
+type Cluster struct {
+	Typed   kubernetes.Interface
+	Dynamic dynamic.Interface
+}
+
+// Connect resolves the ambient credentials and returns the connections they
+// grant: the in-cluster service account when running as a pod, and the
+// kubeconfig otherwise. Both clients share one resolved configuration.
+func Connect() (Cluster, error) {
+	config, err := restConfig()
+	if err != nil {
+		return Cluster{}, err
+	}
+
+	typed, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return Cluster{}, fmt.Errorf("failed to create client: %v", err)
+	}
+
+	dyn, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return Cluster{}, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
+	return Cluster{Typed: typed, Dynamic: dyn}, nil
+}
+
+// restConfig prefers the in-cluster service account, and falls back to the
+// kubeconfig named by KUBECONFIG or found in the user's home directory.
+func restConfig() (*rest.Config, error) {
+	if config, err := rest.InClusterConfig(); err == nil {
+		return config, nil
+	}
+
+	kubeconfigPath := os.Getenv("KUBECONFIG")
+	if kubeconfigPath == "" {
+		if homeDir, err := os.UserHomeDir(); err == nil {
+			kubeconfigPath = filepath.Join(homeDir, ".kube", "config")
+		}
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create config: %v (try setting KUBECONFIG environment variable)", err)
+	}
+
+	return config, nil
+}

--- a/pkg/janitor/config_test.go
+++ b/pkg/janitor/config_test.go
@@ -266,11 +266,7 @@ func TestNamespaceCleanupWithTTL(t *testing.T) {
 				DryRun:            true,
 			}
 
-			j := &Janitor{
-				client: clientset,
-				config: config,
-				cache:  make(map[string]interface{}),
-			}
+			j := New(config, Cluster{Typed: clientset})
 
 			// Track which namespaces were processed by checking the matchesResourceFilter
 			for _, ns := range tt.namespaces {
@@ -336,11 +332,7 @@ func TestNamespaceClusterResourcesBug(t *testing.T) {
 	// Create fake client and add the namespace
 	clientset := fake.NewSimpleClientset(testNamespace)
 
-	j := &Janitor{
-		client: clientset,
-		config: config,
-		cache:  make(map[string]interface{}),
-	}
+	j := New(config, Cluster{Typed: clientset})
 
 	// Test using the real namespace object (as cleanupNamespaces does)
 	matches := j.matchesResourceFilter(mustTarget(t, testNamespace))

--- a/pkg/janitor/context.go
+++ b/pkg/janitor/context.go
@@ -47,7 +47,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 	isReferenced := false
 
 	// Check if PVC is mounted by any pods
-	pods, err := j.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	pods, err := j.cluster.Typed.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods: %v", err)
 	}
@@ -66,7 +66,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 	}
 
 	// Check if PVC is referenced by StatefulSets
-	statefulsets, err := j.client.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
+	statefulsets, err := j.cluster.Typed.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list statefulsets: %v", err)
 	}
@@ -128,7 +128,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 }
 
 func (j *Janitor) isPVCReferencedByDeployments(ctx context.Context, namespace, pvcName string) (bool, error) {
-	deployments, err := j.client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+	deployments, err := j.cluster.Typed.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -145,7 +145,7 @@ func (j *Janitor) isPVCReferencedByDeployments(ctx context.Context, namespace, p
 }
 
 func (j *Janitor) isPVCReferencedByJobs(ctx context.Context, namespace, pvcName string) (bool, error) {
-	jobs, err := j.client.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
+	jobs, err := j.cluster.Typed.BatchV1().Jobs(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -162,7 +162,7 @@ func (j *Janitor) isPVCReferencedByJobs(ctx context.Context, namespace, pvcName 
 }
 
 func (j *Janitor) isPVCReferencedByCronJobs(ctx context.Context, namespace, pvcName string) (bool, error) {
-	cronJobs, err := j.client.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
+	cronJobs, err := j.cluster.Typed.BatchV1().CronJobs(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/pkg/janitor/context_test.go
+++ b/pkg/janitor/context_test.go
@@ -101,10 +101,7 @@ func TestGetPVCContext(t *testing.T) {
 			clientset := fake.NewSimpleClientset()
 
 			// Create janitor instance with fake client
-			j := &Janitor{
-				client: clientset,
-				cache:  make(map[string]interface{}),
-			}
+			j := New(&Config{}, Cluster{Typed: clientset})
 
 			// Create test resources in fake client
 			if tt.pvc != nil {
@@ -175,13 +172,7 @@ func TestGetResourceContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j := &Janitor{
-				client: fake.NewSimpleClientset(),
-				config: &Config{
-					ResourceContextHook: tt.hook,
-				},
-				cache: make(map[string]interface{}),
-			}
+			j := New(&Config{ResourceContextHook: tt.hook}, Cluster{Typed: fake.NewSimpleClientset()})
 
 			// Run setup if provided
 			if tt.setup != nil {

--- a/pkg/janitor/effects.go
+++ b/pkg/janitor/effects.go
@@ -102,7 +102,7 @@ func (j *Janitor) createEvent(ctx context.Context, t Target, message, reason str
 		},
 	}
 
-	if _, err := j.client.CoreV1().Events(eventNamespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
+	if _, err := j.cluster.Typed.CoreV1().Events(eventNamespace).Create(ctx, event, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("failed to create event: %v", err)
 	}
 
@@ -122,10 +122,10 @@ func (j *Janitor) deleteResource(ctx context.Context, t Target) error {
 	var err error
 	if t.Namespace != "" {
 		j.infoLog("Deleting namespaced resource %s/%s", t.Namespace, t.Name)
-		err = j.dynamicClient.Resource(t.GVR).Namespace(t.Namespace).Delete(ctx, t.Name, deleteOptions)
+		err = j.cluster.Dynamic.Resource(t.GVR).Namespace(t.Namespace).Delete(ctx, t.Name, deleteOptions)
 	} else {
 		j.infoLog("Deleting cluster-scoped resource %s", t.Name)
-		err = j.dynamicClient.Resource(t.GVR).Delete(ctx, t.Name, deleteOptions)
+		err = j.cluster.Dynamic.Resource(t.GVR).Delete(ctx, t.Name, deleteOptions)
 	}
 	if err != nil {
 		return fmt.Errorf("failed to delete resource: %v", err)

--- a/pkg/janitor/effects_test.go
+++ b/pkg/janitor/effects_test.go
@@ -27,30 +27,39 @@ type effectsFixture struct {
 func newEffectsFixture(t *testing.T, cfg *Config) effectsFixture {
 	t.Helper()
 
-	obj := podObject(time.Hour, map[string]string{TTLAnnotation: "1h"})
-
-	scheme := runtime.NewScheme()
-	dyn := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-		scheme,
-		map[schema.GroupVersionResource]string{podGVR: "PodList"},
-		obj,
-	)
+	obj := podObject("staging", "web", time.Hour, map[string]string{TTLAnnotation: "1h"})
 
 	return effectsFixture{
-		janitor: &Janitor{
-			client:        fake.NewSimpleClientset(),
-			dynamicClient: dyn,
-			config:        cfg,
-			cache:         make(map[string]interface{}),
-		},
+		janitor: New(cfg, Cluster{
+			Typed:   fake.NewSimpleClientset(),
+			Dynamic: podDynamicClient(obj),
+		}),
 		target: mustTarget(t, obj),
 	}
+}
+
+// podDynamicClient is a dynamic fake that knows how to list pods.
+func podDynamicClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{podGVR: "PodList"},
+		objects...,
+	)
+}
+
+// podExists reports whether the janitor's cluster still holds the named pod.
+func podExists(t *testing.T, j *Janitor, namespace, name string) bool {
+	t.Helper()
+
+	_, err := j.cluster.Dynamic.Resource(podGVR).Namespace(namespace).
+		Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
 }
 
 func (f effectsFixture) events(t *testing.T) []string {
 	t.Helper()
 
-	list, err := f.janitor.client.CoreV1().Events("staging").List(context.Background(), metav1.ListOptions{})
+	list, err := f.janitor.cluster.Typed.CoreV1().Events("staging").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("listing events: %v", err)
 	}
@@ -60,14 +69,6 @@ func (f effectsFixture) events(t *testing.T) []string {
 		reasons = append(reasons, e.Reason)
 	}
 	return reasons
-}
-
-func (f effectsFixture) podExists(t *testing.T) bool {
-	t.Helper()
-
-	_, err := f.janitor.dynamicClient.Resource(podGVR).Namespace("staging").
-		Get(context.Background(), "web", metav1.GetOptions{})
-	return err == nil
 }
 
 func TestApplyDelete(t *testing.T) {
@@ -88,7 +89,7 @@ func TestApplyDelete(t *testing.T) {
 	if got := f.events(t); len(got) != 1 || got[0] != "TTLExpired" {
 		t.Errorf("event reasons = %v, want [TTLExpired]", got)
 	}
-	if f.podExists(t) {
+	if podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
 		t.Error("pod still exists, want it deleted")
 	}
 }
@@ -103,7 +104,7 @@ func TestApplyNone(t *testing.T) {
 	if got := f.events(t); len(got) != 0 {
 		t.Errorf("event reasons = %v, want none", got)
 	}
-	if !f.podExists(t) {
+	if !podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
 		t.Error("pod was deleted, want it left alone")
 	}
 }
@@ -124,7 +125,7 @@ func TestApplyDryRunWritesNothing(t *testing.T) {
 	if got := f.events(t); len(got) != 0 {
 		t.Errorf("event reasons = %v, want none in dry run", got)
 	}
-	if !f.podExists(t) {
+	if !podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
 		t.Error("pod was deleted in dry run, want it left alone")
 	}
 }
@@ -139,7 +140,7 @@ func TestApplyStampsEventsWithTheDecisionTime(t *testing.T) {
 		t.Fatalf("Apply() error = %v", err)
 	}
 
-	list, err := f.janitor.client.CoreV1().Events("staging").List(context.Background(), metav1.ListOptions{})
+	list, err := f.janitor.cluster.Typed.CoreV1().Events("staging").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("listing events: %v", err)
 	}
@@ -154,8 +155,8 @@ func TestApplyStampsEventsWithTheDecisionTime(t *testing.T) {
 	if !event.LastTimestamp.Time.Equal(now) {
 		t.Errorf("LastTimestamp = %v, want %v", event.LastTimestamp.Time, now)
 	}
-	if event.InvolvedObject.Kind != "Pod" || event.InvolvedObject.UID != "pod-uid" {
-		t.Errorf("InvolvedObject = %+v, want Pod/pod-uid", event.InvolvedObject)
+	if event.InvolvedObject.Kind != "Pod" || event.InvolvedObject.UID != f.target.UID {
+		t.Errorf("InvolvedObject = %+v, want Pod/%s", event.InvolvedObject, f.target.UID)
 	}
 }
 
@@ -218,7 +219,7 @@ func TestApplyNotify(t *testing.T) {
 	if got := f.events(t); len(got) != 1 || got[0] != "DeleteNotification" {
 		t.Errorf("event reasons = %v, want [DeleteNotification]", got)
 	}
-	if !f.podExists(t) {
+	if !podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
 		t.Error("pod was deleted on a notify verdict, want it left alone")
 	}
 

--- a/pkg/janitor/janitor.go
+++ b/pkg/janitor/janitor.go
@@ -4,85 +4,32 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 // Janitor handles the cleanup of Kubernetes resources
 type Janitor struct {
-	client        kubernetes.Interface
-	dynamicClient dynamic.Interface
-	config        *Config
-	cache         map[string]interface{}
-	debug         bool
+	cluster Cluster
+	config  *Config
+	cache   map[string]interface{}
 }
 
-// New creates a new Janitor instance
-func New(config *Config) (*Janitor, error) {
-	// Create the Kubernetes client
-	client, err := getKubeClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Kubernetes client: %v", err)
-	}
-
-	dynamicClient, err := getDynamicClient()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
-	}
-
+// New creates a Janitor that works through the given Cluster.
+func New(config *Config, cluster Cluster) *Janitor {
 	return &Janitor{
-		client:        client,
-		dynamicClient: dynamicClient,
-		config:        config,
-		cache:         make(map[string]interface{}),
-		debug:         config.Debug,
-	}, nil
-}
-
-// getDynamicClient creates a new dynamic client for the Kubernetes cluster
-func getDynamicClient() (dynamic.Interface, error) {
-	var config *rest.Config
-	var err error
-
-	// Try in-cluster config first
-	config, err = rest.InClusterConfig()
-	if err != nil {
-		// Fall back to kubeconfig
-		kubeconfigPath := os.Getenv("KUBECONFIG")
-		if kubeconfigPath == "" {
-			// If KUBECONFIG is not set, use default location
-			homeDir, err := os.UserHomeDir()
-			if err == nil {
-				kubeconfigPath = filepath.Join(homeDir, ".kube", "config")
-			}
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create config: %v (try setting KUBECONFIG environment variable)", err)
-		}
+		cluster: cluster,
+		config:  config,
+		cache:   make(map[string]interface{}),
 	}
-
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
-	}
-
-	return dynamicClient, nil
 }
 
 // debugLog logs a message if debug mode is enabled
 func (j *Janitor) debugLog(format string, args ...interface{}) {
-	if j.debug {
+	if j.config.Debug {
 		log.Printf("DEBUG: "+format, args...)
 	}
 }
@@ -98,7 +45,7 @@ func (j *Janitor) infoLog(format string, args ...interface{}) {
 func (j *Janitor) CleanUp(ctx context.Context) error {
 	j.debugLog("Starting cleanup run")
 
-	resourceTypes, err := GetResourceTypes(j.client)
+	resourceTypes, err := GetResourceTypes(j.cluster.Typed)
 	if err != nil {
 		return fmt.Errorf("failed to get resource types: %v", err)
 	}
@@ -137,7 +84,7 @@ func (j *Janitor) cleanupResourceType(ctx context.Context, resourceType Resource
 
 	j.debugLog("Getting namespaces for resource type: %s", resourceType.Kind)
 	// Get all namespaces
-	namespaces, err := j.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	namespaces, err := j.cluster.Typed.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list namespaces: %v", err)
 	}
@@ -237,7 +184,7 @@ func (j *Janitor) listNamespacedResources(ctx context.Context, resourceType Reso
 		Resource: resourceType.Plural,
 	}
 
-	list, err := j.dynamicClient.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	list, err := j.cluster.Dynamic.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list %s in namespace %s: %v", resourceType.Kind, namespace, err)
 	}
@@ -261,7 +208,7 @@ func (j *Janitor) listClusterResources(ctx context.Context, resourceType Resourc
 		Resource: resourceType.Plural,
 	}
 
-	list, err := j.dynamicClient.Resource(gvr).List(ctx, metav1.ListOptions{})
+	list, err := j.cluster.Dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list cluster-scoped %s: %v", resourceType.Kind, err)
 	}
@@ -276,38 +223,6 @@ func (j *Janitor) listClusterResources(ctx context.Context, resourceType Resourc
 	}
 
 	return resources, nil
-}
-
-// getKubeClient creates a new Kubernetes client
-func getKubeClient() (kubernetes.Interface, error) {
-	var config *rest.Config
-	var err error
-
-	// Try in-cluster config first
-	config, err = rest.InClusterConfig()
-	if err != nil {
-		// Fall back to kubeconfig
-		kubeconfigPath := os.Getenv("KUBECONFIG")
-		if kubeconfigPath == "" {
-			// If KUBECONFIG is not set, use default location
-			homeDir, err := os.UserHomeDir()
-			if err == nil {
-				kubeconfigPath = filepath.Join(homeDir, ".kube", "config")
-			}
-		}
-
-		config, err = clientcmd.BuildConfigFromFlags("", kubeconfigPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create config: %v (try setting KUBECONFIG environment variable)", err)
-		}
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create client: %v", err)
-	}
-
-	return clientset, nil
 }
 
 func (j *Janitor) handleResource(ctx context.Context, t Target, counter map[string]int) error {
@@ -365,7 +280,7 @@ func (j *Janitor) cleanupNamespaces(ctx context.Context, counter map[string]int)
 	}
 
 	j.debugLog("Listing all namespaces")
-	namespaces, err := j.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	namespaces, err := j.cluster.Typed.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list namespaces: %v", err)
 	}
@@ -439,7 +354,7 @@ func (j *Janitor) logCleanupSummary(counter map[string]int) {
 
 	log.Printf("Clean up run completed: %s", strings.Join(stats, ", "))
 
-	if j.debug {
+	if j.config.Debug {
 		j.debugLog("Detailed counter values:")
 		for k, v := range counter {
 			j.debugLog("  %s: %d", k, v)

--- a/pkg/janitor/janitor_test.go
+++ b/pkg/janitor/janitor_test.go
@@ -1,0 +1,146 @@
+package janitor
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// newRunFixture is a Janitor handed fake connections holding the given pods, the
+// namespaces they live in, and the discovery a run needs to find them. Because
+// New accepts a Cluster, a whole run goes through the interface main uses.
+func newRunFixture(t *testing.T, cfg *Config, pods ...*unstructured.Unstructured) *Janitor {
+	t.Helper()
+
+	objects := make([]runtime.Object, 0, len(pods))
+	var namespaces []runtime.Object
+	seen := map[string]bool{}
+
+	for _, p := range pods {
+		objects = append(objects, p)
+
+		ns := p.GetNamespace()
+		if !seen[ns] {
+			seen[ns] = true
+			namespaces = append(namespaces,
+				&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+		}
+	}
+
+	typed := fake.NewSimpleClientset(namespaces...)
+	typed.Discovery().(*fakediscovery.FakeDiscovery).Resources = []*metav1.APIResourceList{{
+		GroupVersion: "v1",
+		APIResources: []metav1.APIResource{
+			{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: []string{"list", "delete"}},
+		},
+	}}
+
+	return New(cfg, Cluster{Typed: typed, Dynamic: podDynamicClient(objects...)})
+}
+
+// expiredPod carries an expiry annotation in the past, so any run that considers
+// it deletes it.
+func expiredPod(namespace, name string) *unstructured.Unstructured {
+	return podObject(namespace, name, 24*time.Hour, map[string]string{
+		ExpiryAnnotation: time.Now().Add(-time.Hour).Format(time.RFC3339),
+	})
+}
+
+// splitRef splits a "namespace/name" pod reference.
+func splitRef(t *testing.T, ref string) (string, string) {
+	t.Helper()
+
+	namespace, name, ok := strings.Cut(ref, "/")
+	if !ok {
+		t.Fatalf("malformed pod reference %q", ref)
+	}
+	return namespace, name
+}
+
+func TestCleanUp(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*Config)
+		pods      []string
+		cancelled bool
+		// wantAlive lists the pods that must survive the run; every other pod in
+		// pods must be gone.
+		wantAlive []string
+	}{
+		{
+			name: "deletes an expired resource",
+			pods: []string{"staging/web"},
+		},
+		{
+			name:      "leaves an excluded namespace alone",
+			configure: func(c *Config) { c.ExcludeNamespaces = []string{"kube-system"} },
+			pods:      []string{"staging/web", "kube-system/coredns"},
+			wantAlive: []string{"kube-system/coredns"},
+		},
+		{
+			name:      "leaves an excluded resource type alone",
+			configure: func(c *Config) { c.ExcludeResources = []string{"pods"} },
+			pods:      []string{"staging/web"},
+			wantAlive: []string{"staging/web"},
+		},
+		{
+			name:      "deletes nothing in a dry run",
+			configure: func(c *Config) { c.DryRun = true },
+			pods:      []string{"staging/web"},
+			wantAlive: []string{"staging/web"},
+		},
+		{
+			name:      "stops on a cancelled context",
+			pods:      []string{"staging/web"},
+			cancelled: true,
+			wantAlive: []string{"staging/web"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := NewConfig()
+			if tt.configure != nil {
+				tt.configure(cfg)
+			}
+
+			pods := make([]*unstructured.Unstructured, 0, len(tt.pods))
+			for _, ref := range tt.pods {
+				namespace, name := splitRef(t, ref)
+				pods = append(pods, expiredPod(namespace, name))
+			}
+
+			j := newRunFixture(t, cfg, pods...)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			if tt.cancelled {
+				cancel()
+			}
+
+			if err := j.CleanUp(ctx); err != nil {
+				t.Fatalf("CleanUp() error = %v", err)
+			}
+
+			alive := map[string]bool{}
+			for _, ref := range tt.wantAlive {
+				alive[ref] = true
+			}
+
+			for _, ref := range tt.pods {
+				namespace, name := splitRef(t, ref)
+				if got := podExists(t, j, namespace, name); got != alive[ref] {
+					t.Errorf("pod %s exists = %v, want %v", ref, got, alive[ref])
+				}
+			}
+		})
+	}
+}

--- a/pkg/janitor/verdict_test.go
+++ b/pkg/janitor/verdict_test.go
@@ -12,13 +12,12 @@ import (
 // now is the fixed clock every case in this file is judged against.
 var now = time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 
-// podObject builds the pod every test in this package uses: staging/web, created
-// at the given age, with the given annotations.
-func podObject(age time.Duration, annotations map[string]string) *unstructured.Unstructured {
+// podObject builds a pod created at the given age, with the given annotations.
+func podObject(namespace, name string, age time.Duration, annotations map[string]string) *unstructured.Unstructured {
 	metadata := map[string]interface{}{
-		"name":              "web",
-		"namespace":         "staging",
-		"uid":               "pod-uid",
+		"name":              name,
+		"namespace":         namespace,
+		"uid":               namespace + "/" + name,
 		"creationTimestamp": now.Add(-age).Format(time.RFC3339),
 	}
 	if annotations != nil {
@@ -36,7 +35,7 @@ func podObject(age time.Duration, annotations map[string]string) *unstructured.U
 func pod(t *testing.T, age time.Duration, annotations map[string]string) Target {
 	t.Helper()
 
-	return mustTarget(t, podObject(age, annotations))
+	return mustTarget(t, podObject("staging", "web", age, annotations))
 }
 
 func toStringMap(in map[string]string) map[string]interface{} {


### PR DESCRIPTION
`New` takes a `Cluster` holding the typed and dynamic clients. `Connect` resolves the ambient credentials once — the in-cluster service account when running as a pod, the kubeconfig otherwise — and builds both clients from one `rest.Config`. `main` calls `Connect` and passes the result to `New`.

This replaces `getKubeClient` and `getDynamicClient`, which each resolved the kubeconfig separately with the same 21 lines.

`Janitor` holds the `Cluster` rather than two separate client fields, and no longer carries a `debug` field duplicating `config.Debug`.

## Tests

Tests construct a `Janitor` through `New` with fake clients instead of building the struct by hand. `janitor_test.go` runs `CleanUp` end to end against fakes, covering deletion of an expired resource, namespace exclusion, resource-type exclusion, dry run, and a cancelled context.

Package coverage goes from 48.4% to 66.6%. In `janitor.go`, only `listClusterResources` and `resourceContext` remain uncovered.

## Docs

`CONTEXT.md` gains **Cluster** and the **Connect** module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)