### PR TITLE
fix: carry the listed resource type into the Target

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,6 +25,12 @@ the configured deployment-time annotation when present, and from the resource's
 creation timestamp otherwise.
 _Avoid_: Start time, age, created at
 
+**Resource type**:
+A kind as the cluster's discovery reports it, carrying the plural a Target is
+listed and deleted through. A Target is built from the type it was listed as, so
+the plural is never derived from the kind.
+_Avoid_: Kind (one field of a Resource type), GVR, plural
+
 **Verdict**:
 The conclusion about one Target: leave it alone, delete it, or warn that it will be
 deleted. A Verdict carries the reason it was reached, so nothing downstream has to

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ configured via environment variable `INCLUDE_RESOURCES`. This option
 can be used if you want to clean up only certain resource types,
 e.g. only `deployments`. Names are the plural your cluster's API
 reports for the resource, as listed by `kubectl api-resources`, so
-irregular plurals are `ingresses` and `networkpolicies`.
+irregular plurals are `ingresses` and `networkpolicies`. Earlier
+versions derived these names by appending an "s" to the kind, so a
+configuration written against that (`ingresss`, `networkpolicys`) no
+longer matches anything and must be corrected.
 
 `--exclude-resources`
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ does not take effect for dry runs.
 : Include resources for clean up (default: all resources), can also be
 configured via environment variable `INCLUDE_RESOURCES`. This option
 can be used if you want to clean up only certain resource types,
-e.g. only `deployments`.
+e.g. only `deployments`. Names are the plural your cluster's API
+reports for the resource, as listed by `kubectl api-resources`, so
+irregular plurals are `ingresses` and `networkpolicies`.
 
 `--exclude-resources`
 
@@ -284,8 +286,10 @@ output/statistics.
 `resources`
 
 : List of resources (e.g. `deployments`, `namespaces`, ..) this rule
-should be applied to. The special value `*` will match all resource
-types.
+should be applied to. Names are the plural your cluster's API reports
+for the resource, as listed by `kubectl api-resources`, so irregular
+plurals are `ingresses` and `networkpolicies`. The special value `*`
+will match all resource types.
 
 `jmespath`
 

--- a/pkg/janitor/config_test.go
+++ b/pkg/janitor/config_test.go
@@ -282,7 +282,7 @@ func TestNamespaceCleanupWithTTL(t *testing.T) {
 						},
 					},
 				}
-				matches := j.matchesResourceFilter(mustTarget(t, nsUnstructured))
+				matches := j.matchesResourceFilter(mustTarget(t, nsUnstructured, namespaceResourceType))
 
 				expectedProcessed := false
 				for _, expected := range tt.expectProcessed {
@@ -335,7 +335,7 @@ func TestNamespaceClusterResourcesBug(t *testing.T) {
 	j := New(config, Cluster{Typed: clientset})
 
 	// Test using the real namespace object (as cleanupNamespaces does)
-	matches := j.matchesResourceFilter(mustTarget(t, testNamespace))
+	matches := j.matchesResourceFilter(mustTarget(t, testNamespace, namespaceResourceType))
 
 	// According to the documentation, namespaces should be processed by default
 	// without needing --include-cluster-resources flag
@@ -345,7 +345,7 @@ func TestNamespaceClusterResourcesBug(t *testing.T) {
 
 	// Now test with include-cluster-resources = true (should definitely work)
 	config.IncludeClusterResources = true
-	matches = j.matchesResourceFilter(mustTarget(t, testNamespace))
+	matches = j.matchesResourceFilter(mustTarget(t, testNamespace, namespaceResourceType))
 	if !matches {
 		t.Errorf("Namespace should definitely be processed with --include-cluster-resources flag, but matchesResourceFilter returned false")
 	}

--- a/pkg/janitor/context_test.go
+++ b/pkg/janitor/context_test.go
@@ -11,6 +11,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+// pvcResourceType is the Resource type persistent volume claims are listed as.
+var pvcResourceType = ResourceType{
+	Version: "v1", Kind: "PersistentVolumeClaim", Plural: "persistentvolumeclaims", Namespaced: true,
+}
+
 func TestGetPVCContext(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -127,7 +132,7 @@ func TestGetPVCContext(t *testing.T) {
 
 			// Get PVC context
 			ctx := context.Background()
-			got, err := j.getPVCContext(ctx, mustTarget(t, tt.pvc))
+			got, err := j.getPVCContext(ctx, mustTarget(t, tt.pvc, pvcResourceType))
 			if err != nil {
 				t.Fatalf("getPVCContext() error = %v", err)
 			}
@@ -179,7 +184,7 @@ func TestGetResourceContext(t *testing.T) {
 				tt.setup(t, j)
 			}
 
-			got, err := j.getResourceContext(context.Background(), mustTarget(t, tt.resource))
+			got, err := j.getResourceContext(context.Background(), mustTarget(t, tt.resource, podResourceType))
 			if err != nil {
 				t.Fatalf("getResourceContext() error = %v", err)
 			}

--- a/pkg/janitor/effects_test.go
+++ b/pkg/janitor/effects_test.go
@@ -33,6 +33,13 @@ func newEffectsFixture(t *testing.T, cfg *Config) effectsFixture {
 	}
 }
 
+// exists reports whether the fixture's pod is still in the cluster.
+func (f effectsFixture) exists(t *testing.T) bool {
+	t.Helper()
+
+	return resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name)
+}
+
 func (f effectsFixture) events(t *testing.T) []string {
 	t.Helper()
 
@@ -66,7 +73,7 @@ func TestApplyDelete(t *testing.T) {
 	if got := f.events(t); len(got) != 1 || got[0] != "TTLExpired" {
 		t.Errorf("event reasons = %v, want [TTLExpired]", got)
 	}
-	if resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
+	if f.exists(t) {
 		t.Error("pod still exists, want it deleted")
 	}
 }
@@ -81,7 +88,7 @@ func TestApplyNone(t *testing.T) {
 	if got := f.events(t); len(got) != 0 {
 		t.Errorf("event reasons = %v, want none", got)
 	}
-	if !resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
+	if !f.exists(t) {
 		t.Error("pod was deleted, want it left alone")
 	}
 }
@@ -102,7 +109,7 @@ func TestApplyDryRunWritesNothing(t *testing.T) {
 	if got := f.events(t); len(got) != 0 {
 		t.Errorf("event reasons = %v, want none in dry run", got)
 	}
-	if !resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
+	if !f.exists(t) {
 		t.Error("pod was deleted in dry run, want it left alone")
 	}
 }
@@ -196,7 +203,7 @@ func TestApplyNotify(t *testing.T) {
 	if got := f.events(t); len(got) != 1 || got[0] != "DeleteNotification" {
 		t.Errorf("event reasons = %v, want [DeleteNotification]", got)
 	}
-	if !resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
+	if !f.exists(t) {
 		t.Error("pod was deleted on a notify verdict, want it left alone")
 	}
 

--- a/pkg/janitor/effects_test.go
+++ b/pkg/janitor/effects_test.go
@@ -10,13 +10,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
-
-var podGVR = schema.GroupVersionResource{Version: "v1", Resource: "pods"}
 
 // effectsFixture is a janitor wired to fake clients, holding one pod.
 type effectsFixture struct {
@@ -32,28 +27,10 @@ func newEffectsFixture(t *testing.T, cfg *Config) effectsFixture {
 	return effectsFixture{
 		janitor: New(cfg, Cluster{
 			Typed:   fake.NewSimpleClientset(),
-			Dynamic: podDynamicClient(obj),
+			Dynamic: dynamicClientFor(podResourceType, obj),
 		}),
-		target: mustTarget(t, obj),
+		target: mustTarget(t, obj, podResourceType),
 	}
-}
-
-// podDynamicClient is a dynamic fake that knows how to list pods.
-func podDynamicClient(objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
-	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
-		runtime.NewScheme(),
-		map[schema.GroupVersionResource]string{podGVR: "PodList"},
-		objects...,
-	)
-}
-
-// podExists reports whether the janitor's cluster still holds the named pod.
-func podExists(t *testing.T, j *Janitor, namespace, name string) bool {
-	t.Helper()
-
-	_, err := j.cluster.Dynamic.Resource(podGVR).Namespace(namespace).
-		Get(context.Background(), name, metav1.GetOptions{})
-	return err == nil
 }
 
 func (f effectsFixture) events(t *testing.T) []string {
@@ -89,7 +66,7 @@ func TestApplyDelete(t *testing.T) {
 	if got := f.events(t); len(got) != 1 || got[0] != "TTLExpired" {
 		t.Errorf("event reasons = %v, want [TTLExpired]", got)
 	}
-	if podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
+	if resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
 		t.Error("pod still exists, want it deleted")
 	}
 }
@@ -104,7 +81,7 @@ func TestApplyNone(t *testing.T) {
 	if got := f.events(t); len(got) != 0 {
 		t.Errorf("event reasons = %v, want none", got)
 	}
-	if !podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
+	if !resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
 		t.Error("pod was deleted, want it left alone")
 	}
 }
@@ -125,7 +102,7 @@ func TestApplyDryRunWritesNothing(t *testing.T) {
 	if got := f.events(t); len(got) != 0 {
 		t.Errorf("event reasons = %v, want none in dry run", got)
 	}
-	if !podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
+	if !resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
 		t.Error("pod was deleted in dry run, want it left alone")
 	}
 }
@@ -219,7 +196,7 @@ func TestApplyNotify(t *testing.T) {
 	if got := f.events(t); len(got) != 1 || got[0] != "DeleteNotification" {
 		t.Errorf("event reasons = %v, want [DeleteNotification]", got)
 	}
-	if !podExists(t, f.janitor, f.target.Namespace, f.target.Name) {
+	if !resourceExists(t, f.janitor, podResourceType, f.target.Namespace, f.target.Name) {
 		t.Error("pod was deleted on a notify verdict, want it left alone")
 	}
 

--- a/pkg/janitor/janitor.go
+++ b/pkg/janitor/janitor.go
@@ -8,18 +8,13 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/dynamic"
 )
 
 // namespaceResourceType is the Resource type namespaces are listed and deleted
-// through. Namespaces come from the typed client, which carries no discovery
-// record of its own, and these values are fixed by the Kubernetes API.
-var namespaceResourceType = ResourceType{
-	Version:    "v1",
-	Kind:       "Namespace",
-	Plural:     "namespaces",
-	Namespaced: false,
-}
+// through. cleanupNamespaces lists them through the typed client rather than
+// from the discovered types, so it names the type here; the values are fixed by
+// the Kubernetes API.
+var namespaceResourceType = ResourceType{Version: "v1", Kind: "Namespace", Plural: "namespaces"}
 
 // Janitor handles the cleanup of Kubernetes resources
 type Janitor struct {
@@ -188,18 +183,11 @@ func (j *Janitor) shouldProcessNamespace(namespace string) bool {
 // listTargets lists every resource of the given type as a Target carrying that
 // type, in one namespace or across the cluster when namespace is empty.
 func (j *Janitor) listTargets(ctx context.Context, resourceType ResourceType, namespace string) ([]Target, error) {
-	resource := j.cluster.Dynamic.Resource(resourceType.gvr())
-
-	var lister dynamic.ResourceInterface = resource
-	scope := "cluster-scoped"
-	if namespace != "" {
-		lister = resource.Namespace(namespace)
-		scope = "namespace " + namespace
-	}
-
-	list, err := lister.List(ctx, metav1.ListOptions{})
+	// An empty namespace lists across the cluster.
+	list, err := j.cluster.Dynamic.Resource(resourceType.gvr()).Namespace(namespace).
+		List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list %s in %s: %v", resourceType.Kind, scope, err)
+		return nil, err
 	}
 
 	targets := make([]Target, 0, len(list.Items))

--- a/pkg/janitor/janitor.go
+++ b/pkg/janitor/janitor.go
@@ -8,8 +8,18 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 )
+
+// namespaceResourceType is the Resource type namespaces are listed and deleted
+// through. Namespaces come from the typed client, which carries no discovery
+// record of its own, and these values are fixed by the Kubernetes API.
+var namespaceResourceType = ResourceType{
+	Version:    "v1",
+	Kind:       "Namespace",
+	Plural:     "namespaces",
+	Namespaced: false,
+}
 
 // Janitor handles the cleanup of Kubernetes resources
 type Janitor struct {
@@ -93,8 +103,8 @@ func (j *Janitor) cleanupResourceType(ctx context.Context, resourceType Resource
 	if resourceType.Namespaced {
 		j.debugLog("Processing namespaced resources for type: %s", resourceType.Kind)
 
-		// Collect all resources from all namespaces first
-		var allResources []metav1.Object
+		// Collect all targets from all namespaces first
+		var allTargets []Target
 
 		for _, ns := range namespaces.Items {
 			// Skip excluded namespaces
@@ -104,30 +114,28 @@ func (j *Janitor) cleanupResourceType(ctx context.Context, resourceType Resource
 			}
 
 			j.debugLog("Listing resources of type %s in namespace %s", resourceType.Kind, ns.Name)
-			resources, err := j.listNamespacedResources(ctx, resourceType, ns.Name)
+			targets, err := j.listTargets(ctx, resourceType, ns.Name)
 			if err != nil {
 				log.Printf("Error listing %s in namespace %s: %v", resourceType.Kind, ns.Name, err)
 				continue
 			}
-			j.debugLog("Found %d resources of type %s in namespace %s", len(resources), resourceType.Kind, ns.Name)
+			j.debugLog("Found %d resources of type %s in namespace %s", len(targets), resourceType.Kind, ns.Name)
 
-			allResources = append(allResources, resources...)
+			allTargets = append(allTargets, targets...)
 		}
 
-		// Process resources serially
-		j.processResourcesSerially(ctx, allResources, counter)
+		j.processTargets(ctx, allTargets, counter)
 
 	} else if j.config.IncludeClusterResources {
 		// Process cluster-scoped resources if enabled
 		j.debugLog("Processing cluster-scoped resources for type: %s", resourceType.Kind)
-		resources, err := j.listClusterResources(ctx, resourceType)
+		targets, err := j.listTargets(ctx, resourceType, "")
 		if err != nil {
 			return fmt.Errorf("failed to list cluster-scoped %s: %v", resourceType.Kind, err)
 		}
-		j.debugLog("Found %d cluster-scoped resources of type %s", len(resources), resourceType.Kind)
+		j.debugLog("Found %d cluster-scoped resources of type %s", len(targets), resourceType.Kind)
 
-		// Process resources serially
-		j.processResourcesSerially(ctx, resources, counter)
+		j.processTargets(ctx, targets, counter)
 	}
 
 	return nil
@@ -177,52 +185,35 @@ func (j *Janitor) shouldProcessNamespace(namespace string) bool {
 	return false
 }
 
-func (j *Janitor) listNamespacedResources(ctx context.Context, resourceType ResourceType, namespace string) ([]metav1.Object, error) {
-	gvr := schema.GroupVersionResource{
-		Group:    resourceType.Group,
-		Version:  resourceType.Version,
-		Resource: resourceType.Plural,
+// listTargets lists every resource of the given type as a Target carrying that
+// type, in one namespace or across the cluster when namespace is empty.
+func (j *Janitor) listTargets(ctx context.Context, resourceType ResourceType, namespace string) ([]Target, error) {
+	resource := j.cluster.Dynamic.Resource(resourceType.gvr())
+
+	var lister dynamic.ResourceInterface = resource
+	scope := "cluster-scoped"
+	if namespace != "" {
+		lister = resource.Namespace(namespace)
+		scope = "namespace " + namespace
 	}
 
-	list, err := j.cluster.Dynamic.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	list, err := lister.List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list %s in namespace %s: %v", resourceType.Kind, namespace, err)
+		return nil, fmt.Errorf("failed to list %s in %s: %v", resourceType.Kind, scope, err)
 	}
 
-	var resources []metav1.Object
-	for _, item := range list.Items {
-		// Convert unstructured.Unstructured to metav1.Object
-		obj := item.DeepCopy()
-		obj.SetKind(resourceType.Kind)
-		obj.SetAPIVersion(fmt.Sprintf("%s/%s", resourceType.Group, resourceType.Version))
-		resources = append(resources, obj)
+	targets := make([]Target, 0, len(list.Items))
+	for i := range list.Items {
+		t, err := newTarget(&list.Items[i], resourceType)
+		if err != nil {
+			log.Printf("Error reading %s %s/%s: %v", resourceType.Kind,
+				list.Items[i].GetNamespace(), list.Items[i].GetName(), err)
+			continue
+		}
+		targets = append(targets, t)
 	}
 
-	return resources, nil
-}
-
-func (j *Janitor) listClusterResources(ctx context.Context, resourceType ResourceType) ([]metav1.Object, error) {
-	gvr := schema.GroupVersionResource{
-		Group:    resourceType.Group,
-		Version:  resourceType.Version,
-		Resource: resourceType.Plural,
-	}
-
-	list, err := j.cluster.Dynamic.Resource(gvr).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list cluster-scoped %s: %v", resourceType.Kind, err)
-	}
-
-	var resources []metav1.Object
-	for _, item := range list.Items {
-		// Convert unstructured.Unstructured to metav1.Object
-		obj := item.DeepCopy()
-		obj.SetKind(resourceType.Kind)
-		obj.SetAPIVersion(fmt.Sprintf("%s/%s", resourceType.Group, resourceType.Version))
-		resources = append(resources, obj)
-	}
-
-	return resources, nil
+	return targets, nil
 }
 
 func (j *Janitor) handleResource(ctx context.Context, t Target, counter map[string]int) error {
@@ -288,41 +279,38 @@ func (j *Janitor) cleanupNamespaces(ctx context.Context, counter map[string]int)
 
 	// handleResource applies the same filter to every target, so there is no
 	// second pass here.
-	candidates := make([]metav1.Object, 0, len(namespaces.Items))
+	candidates := make([]Target, 0, len(namespaces.Items))
 	for i := range namespaces.Items {
-		candidates = append(candidates, &namespaces.Items[i])
+		t, err := newTarget(&namespaces.Items[i], namespaceResourceType)
+		if err != nil {
+			log.Printf("Error reading namespace %s: %v", namespaces.Items[i].Name, err)
+			continue
+		}
+		candidates = append(candidates, t)
 	}
 
-	// Process namespaces serially
-	j.processResourcesSerially(ctx, candidates, counter)
+	j.processTargets(ctx, candidates, counter)
 
 	return nil
 }
 
-// processResourcesSerially processes resources one by one in serial order
-func (j *Janitor) processResourcesSerially(ctx context.Context, resources []metav1.Object, counter map[string]int) {
-	if len(resources) == 0 {
+// processTargets processes targets one by one in serial order
+func (j *Janitor) processTargets(ctx context.Context, targets []Target, counter map[string]int) {
+	if len(targets) == 0 {
 		return
 	}
 
-	j.debugLog("Processing %d resources serially", len(resources))
+	j.debugLog("Processing %d resources serially", len(targets))
 
 	alreadySeen := make(map[string]bool)
 
-	for _, resource := range resources {
+	for _, t := range targets {
 		// Check for context cancellation before processing each resource
 		select {
 		case <-ctx.Done():
 			j.debugLog("Context cancelled, stopping resource processing")
 			return
 		default:
-		}
-
-		t, err := newTarget(resource)
-		if err != nil {
-			log.Printf("Error reading resource %s/%s: %v",
-				resource.GetNamespace(), resource.GetName(), err)
-			continue
 		}
 
 		key := t.describe()

--- a/pkg/janitor/janitor.go
+++ b/pkg/janitor/janitor.go
@@ -111,7 +111,7 @@ func (j *Janitor) cleanupResourceType(ctx context.Context, resourceType Resource
 			j.debugLog("Listing resources of type %s in namespace %s", resourceType.Kind, ns.Name)
 			targets, err := j.listTargets(ctx, resourceType, ns.Name)
 			if err != nil {
-				log.Printf("Error listing %s in namespace %s: %v", resourceType.Kind, ns.Name, err)
+				log.Printf("Error listing %s in namespace %s: %v", resourceType.Plural, ns.Name, err)
 				continue
 			}
 			j.debugLog("Found %d resources of type %s in namespace %s", len(targets), resourceType.Kind, ns.Name)
@@ -126,7 +126,7 @@ func (j *Janitor) cleanupResourceType(ctx context.Context, resourceType Resource
 		j.debugLog("Processing cluster-scoped resources for type: %s", resourceType.Kind)
 		targets, err := j.listTargets(ctx, resourceType, "")
 		if err != nil {
-			return fmt.Errorf("failed to list cluster-scoped %s: %v", resourceType.Kind, err)
+			return fmt.Errorf("failed to list cluster-scoped %s: %v", resourceType.Plural, err)
 		}
 		j.debugLog("Found %d cluster-scoped resources of type %s", len(targets), resourceType.Kind)
 
@@ -183,7 +183,6 @@ func (j *Janitor) shouldProcessNamespace(namespace string) bool {
 // listTargets lists every resource of the given type as a Target carrying that
 // type, in one namespace or across the cluster when namespace is empty.
 func (j *Janitor) listTargets(ctx context.Context, resourceType ResourceType, namespace string) ([]Target, error) {
-	// An empty namespace lists across the cluster.
 	list, err := j.cluster.Dynamic.Resource(resourceType.gvr()).Namespace(namespace).
 		List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -192,13 +191,7 @@ func (j *Janitor) listTargets(ctx context.Context, resourceType ResourceType, na
 
 	targets := make([]Target, 0, len(list.Items))
 	for i := range list.Items {
-		t, err := newTarget(&list.Items[i], resourceType)
-		if err != nil {
-			log.Printf("Error reading %s %s/%s: %v", resourceType.Kind,
-				list.Items[i].GetNamespace(), list.Items[i].GetName(), err)
-			continue
-		}
-		targets = append(targets, t)
+		targets = append(targets, newTarget(&list.Items[i], resourceType))
 	}
 
 	return targets, nil
@@ -233,7 +226,7 @@ func (j *Janitor) handleResource(ctx context.Context, t Target, counter map[stri
 	}
 
 	if verdict.Action == ActionDelete {
-		counter[t.GVR.Resource+"-deleted"]++
+		counter[t.plural()+"-deleted"]++
 	}
 
 	return nil
@@ -269,7 +262,9 @@ func (j *Janitor) cleanupNamespaces(ctx context.Context, counter map[string]int)
 	// second pass here.
 	candidates := make([]Target, 0, len(namespaces.Items))
 	for i := range namespaces.Items {
-		t, err := newTarget(&namespaces.Items[i], namespaceResourceType)
+		// A namespace that will not convert is skipped rather than failing the
+		// run, the same way an unreadable resource context is.
+		t, err := newTypedTarget(&namespaces.Items[i], namespaceResourceType)
 		if err != nil {
 			log.Printf("Error reading namespace %s: %v", namespaces.Items[i].Name, err)
 			continue
@@ -349,7 +344,7 @@ func (j *Janitor) matchesResourceFilter(t Target) bool {
 		namespace = name
 	}
 
-	resourceType := t.GVR.Resource
+	resourceType := t.plural()
 
 	// Check if resource type is explicitly excluded
 	for _, excluded := range j.config.ExcludeResources {

--- a/pkg/janitor/janitor_test.go
+++ b/pkg/janitor/janitor_test.go
@@ -43,25 +43,18 @@ func newRunFixture(t *testing.T, cfg *Config, rt ResourceType, objects ...*unstr
 	return New(cfg, Cluster{Typed: typed, Dynamic: dynamicClientFor(rt, listed...)})
 }
 
-// discoveryFor reports the given type, alongside the core group a run always
-// asks for first.
+// discoveryFor reports the given type. Discovery returns the first list matching
+// a group version, so the trailing core-group entry only answers the "v1" lookup
+// GetResourceTypes always makes first, and is shadowed for a core-group type.
 func discoveryFor(rt ResourceType) []*metav1.APIResourceList {
-	entry := metav1.APIResource{
-		Name:       rt.Plural,
-		Kind:       rt.Kind,
-		Namespaced: rt.Namespaced,
-		Verbs:      []string{"list", "delete"},
-	}
-
-	if rt.Group == "" {
-		return []*metav1.APIResourceList{
-			{GroupVersion: "v1", APIResources: []metav1.APIResource{entry}},
-		}
-	}
-
 	return []*metav1.APIResourceList{
+		{GroupVersion: rt.apiVersion(), APIResources: []metav1.APIResource{{
+			Name:       rt.Plural,
+			Kind:       rt.Kind,
+			Namespaced: rt.Namespaced,
+			Verbs:      []string{"list", "delete"},
+		}}},
 		{GroupVersion: "v1"},
-		{GroupVersion: rt.apiVersion(), APIResources: []metav1.APIResource{entry}},
 	}
 }
 
@@ -196,21 +189,16 @@ func TestCleanUp(t *testing.T) {
 // produced "ingresss", which the include list rejected and the API server would
 // not have recognised.
 func TestCleanUpDeletesAnIrregularlyPluralisedResource(t *testing.T) {
-	ingresses := ResourceType{
-		Group: "networking.k8s.io", Version: "v1",
-		Kind: "Ingress", Plural: "ingresses", Namespaced: true,
-	}
-
 	cfg := NewConfig()
 	cfg.IncludeResources = []string{"ingresses"}
 
-	j := newRunFixture(t, cfg, ingresses, expiredObject(ingresses, "staging", "web"))
+	j := newRunFixture(t, cfg, ingressResourceType, expiredObject(ingressResourceType, "staging", "web"))
 
 	if err := j.CleanUp(context.Background()); err != nil {
 		t.Fatalf("CleanUp() error = %v", err)
 	}
 
-	if resourceExists(t, j, ingresses, "staging", "web") {
+	if resourceExists(t, j, ingressResourceType, "staging", "web") {
 		t.Error("ingress staging/web still exists, want it deleted")
 	}
 }

--- a/pkg/janitor/janitor_test.go
+++ b/pkg/janitor/janitor_test.go
@@ -10,24 +10,26 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	fakediscovery "k8s.io/client-go/discovery/fake"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-// newRunFixture is a Janitor handed fake connections holding the given pods, the
-// namespaces they live in, and the discovery a run needs to find them. Because
+// newRunFixture is a Janitor handed fake connections holding the given resources,
+// the namespaces they live in, and the discovery a run needs to find them. Because
 // New accepts a Cluster, a whole run goes through the interface main uses.
-func newRunFixture(t *testing.T, cfg *Config, pods ...*unstructured.Unstructured) *Janitor {
+func newRunFixture(t *testing.T, cfg *Config, rt ResourceType, objects ...*unstructured.Unstructured) *Janitor {
 	t.Helper()
 
-	objects := make([]runtime.Object, 0, len(pods))
+	listed := make([]runtime.Object, 0, len(objects))
 	var namespaces []runtime.Object
 	seen := map[string]bool{}
 
-	for _, p := range pods {
-		objects = append(objects, p)
+	for _, o := range objects {
+		listed = append(listed, o)
 
-		ns := p.GetNamespace()
+		ns := o.GetNamespace()
 		if !seen[ns] {
 			seen[ns] = true
 			namespaces = append(namespaces,
@@ -36,22 +38,66 @@ func newRunFixture(t *testing.T, cfg *Config, pods ...*unstructured.Unstructured
 	}
 
 	typed := fake.NewSimpleClientset(namespaces...)
-	typed.Discovery().(*fakediscovery.FakeDiscovery).Resources = []*metav1.APIResourceList{{
-		GroupVersion: "v1",
-		APIResources: []metav1.APIResource{
-			{Name: "pods", Kind: "Pod", Namespaced: true, Verbs: []string{"list", "delete"}},
-		},
-	}}
+	typed.Discovery().(*fakediscovery.FakeDiscovery).Resources = discoveryFor(rt)
 
-	return New(cfg, Cluster{Typed: typed, Dynamic: podDynamicClient(objects...)})
+	return New(cfg, Cluster{Typed: typed, Dynamic: dynamicClientFor(rt, listed...)})
 }
 
-// expiredPod carries an expiry annotation in the past, so any run that considers
-// it deletes it.
-func expiredPod(namespace, name string) *unstructured.Unstructured {
-	return podObject(namespace, name, 24*time.Hour, map[string]string{
-		ExpiryAnnotation: time.Now().Add(-time.Hour).Format(time.RFC3339),
-	})
+// discoveryFor reports the given type, alongside the core group a run always
+// asks for first.
+func discoveryFor(rt ResourceType) []*metav1.APIResourceList {
+	entry := metav1.APIResource{
+		Name:       rt.Plural,
+		Kind:       rt.Kind,
+		Namespaced: rt.Namespaced,
+		Verbs:      []string{"list", "delete"},
+	}
+
+	if rt.Group == "" {
+		return []*metav1.APIResourceList{
+			{GroupVersion: "v1", APIResources: []metav1.APIResource{entry}},
+		}
+	}
+
+	return []*metav1.APIResourceList{
+		{GroupVersion: "v1"},
+		{GroupVersion: rt.apiVersion(), APIResources: []metav1.APIResource{entry}},
+	}
+}
+
+// dynamicClientFor is a dynamic fake that knows how to list the given type.
+func dynamicClientFor(rt ResourceType, objects ...runtime.Object) *dynamicfake.FakeDynamicClient {
+	return dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		runtime.NewScheme(),
+		map[schema.GroupVersionResource]string{rt.gvr(): rt.Kind + "List"},
+		objects...,
+	)
+}
+
+// expiredObject carries an expiry annotation in the past, so any run that
+// considers it deletes it.
+func expiredObject(rt ResourceType, namespace, name string) *unstructured.Unstructured {
+	return &unstructured.Unstructured{Object: map[string]interface{}{
+		"kind":       rt.Kind,
+		"apiVersion": rt.apiVersion(),
+		"metadata": map[string]interface{}{
+			"name":              name,
+			"namespace":         namespace,
+			"creationTimestamp": time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+			"annotations": map[string]interface{}{
+				ExpiryAnnotation: time.Now().Add(-time.Hour).Format(time.RFC3339),
+			},
+		},
+	}}
+}
+
+// resourceExists reports whether the janitor's cluster still holds the resource.
+func resourceExists(t *testing.T, j *Janitor, rt ResourceType, namespace, name string) bool {
+	t.Helper()
+
+	_, err := j.cluster.Dynamic.Resource(rt.gvr()).Namespace(namespace).
+		Get(context.Background(), name, metav1.GetOptions{})
+	return err == nil
 }
 
 // splitRef splits a "namespace/name" pod reference.
@@ -115,10 +161,10 @@ func TestCleanUp(t *testing.T) {
 			pods := make([]*unstructured.Unstructured, 0, len(tt.pods))
 			for _, ref := range tt.pods {
 				namespace, name := splitRef(t, ref)
-				pods = append(pods, expiredPod(namespace, name))
+				pods = append(pods, expiredObject(podResourceType, namespace, name))
 			}
 
-			j := newRunFixture(t, cfg, pods...)
+			j := newRunFixture(t, cfg, podResourceType, pods...)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -137,10 +183,34 @@ func TestCleanUp(t *testing.T) {
 
 			for _, ref := range tt.pods {
 				namespace, name := splitRef(t, ref)
-				if got := podExists(t, j, namespace, name); got != alive[ref] {
+				if got := resourceExists(t, j, podResourceType, namespace, name); got != alive[ref] {
 					t.Errorf("pod %s exists = %v, want %v", ref, got, alive[ref])
 				}
 			}
 		})
+	}
+}
+
+// A resource whose plural is not its kind plus "s" has to survive discovery,
+// filtering, rule matching and deletion with that plural intact. Guessing it
+// produced "ingresss", which the include list rejected and the API server would
+// not have recognised.
+func TestCleanUpDeletesAnIrregularlyPluralisedResource(t *testing.T) {
+	ingresses := ResourceType{
+		Group: "networking.k8s.io", Version: "v1",
+		Kind: "Ingress", Plural: "ingresses", Namespaced: true,
+	}
+
+	cfg := NewConfig()
+	cfg.IncludeResources = []string{"ingresses"}
+
+	j := newRunFixture(t, cfg, ingresses, expiredObject(ingresses, "staging", "web"))
+
+	if err := j.CleanUp(context.Background()); err != nil {
+		t.Fatalf("CleanUp() error = %v", err)
+	}
+
+	if resourceExists(t, j, ingresses, "staging", "web") {
+		t.Error("ingress staging/web still exists, want it deleted")
 	}
 }

--- a/pkg/janitor/resources.go
+++ b/pkg/janitor/resources.go
@@ -18,22 +18,19 @@ type ResourceType struct {
 	Namespaced bool
 }
 
+func (rt ResourceType) groupVersion() schema.GroupVersion {
+	return schema.GroupVersion{Group: rt.Group, Version: rt.Version}
+}
+
 // apiVersion renders the group and version the way a Kubernetes object reports
 // it: "v1" for the core group, "group/version" for every other.
 func (rt ResourceType) apiVersion() string {
-	if rt.Group == "" {
-		return rt.Version
-	}
-	return rt.Group + "/" + rt.Version
+	return rt.groupVersion().String()
 }
 
 // gvr is the resource a target of this type is listed and deleted through.
 func (rt ResourceType) gvr() schema.GroupVersionResource {
-	return schema.GroupVersionResource{
-		Group:    rt.Group,
-		Version:  rt.Version,
-		Resource: rt.Plural,
-	}
+	return rt.groupVersion().WithResource(rt.Plural)
 }
 
 // GetResourceTypes returns all available resource types in the cluster

--- a/pkg/janitor/resources.go
+++ b/pkg/janitor/resources.go
@@ -2,17 +2,38 @@ package janitor
 
 import (
 	"fmt"
-	"k8s.io/client-go/kubernetes"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
 )
 
-// ResourceType represents a Kubernetes API resource type
+// ResourceType is a kind as the cluster's discovery reports it, carrying the
+// plural a Target is listed and deleted through.
 type ResourceType struct {
 	Group      string
 	Version    string
 	Kind       string
 	Plural     string
 	Namespaced bool
+}
+
+// apiVersion renders the group and version the way a Kubernetes object reports
+// it: "v1" for the core group, "group/version" for every other.
+func (rt ResourceType) apiVersion() string {
+	if rt.Group == "" {
+		return rt.Version
+	}
+	return rt.Group + "/" + rt.Version
+}
+
+// gvr is the resource a target of this type is listed and deleted through.
+func (rt ResourceType) gvr() schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    rt.Group,
+		Version:  rt.Version,
+		Resource: rt.Plural,
+	}
 }
 
 // GetResourceTypes returns all available resource types in the cluster

--- a/pkg/janitor/rules.go
+++ b/pkg/janitor/rules.go
@@ -55,7 +55,7 @@ func (r *Rule) ValidateAndCompile() error {
 func (r *Rule) Matches(t Target, context map[string]interface{}) bool {
 	matches := false
 	for _, allowedResource := range r.Resources {
-		if allowedResource == "*" || allowedResource == t.GVR.Resource {
+		if allowedResource == "*" || allowedResource == t.plural() {
 			matches = true
 			break
 		}

--- a/pkg/janitor/rules.go
+++ b/pkg/janitor/rules.go
@@ -49,18 +49,13 @@ func (r *Rule) ValidateAndCompile() error {
 	return nil
 }
 
-// Matches checks if the rule matches the given resource and context
-func (r *Rule) Matches(resource map[string]interface{}, context map[string]interface{}) bool {
-	// Check if resource type matches
-	kind, ok := resource["kind"].(string)
-	if !ok {
-		return false
-	}
-	resourceType := fmt.Sprintf("%ss", kind)
-
+// Matches checks if the rule matches the given target and context. The
+// resources list is matched against the plural the target was listed as, so a
+// rule naming an irregular plural applies to it.
+func (r *Rule) Matches(t Target, context map[string]interface{}) bool {
 	matches := false
 	for _, allowedResource := range r.Resources {
-		if allowedResource == "*" || allowedResource == resourceType {
+		if allowedResource == "*" || allowedResource == t.GVR.Resource {
 			matches = true
 			break
 		}
@@ -70,8 +65,8 @@ func (r *Rule) Matches(resource map[string]interface{}, context map[string]inter
 	}
 
 	// Add context to resource for JMESPath evaluation
-	data := make(map[string]interface{})
-	for k, v := range resource {
+	data := make(map[string]interface{}, len(t.Raw)+1)
+	for k, v := range t.Raw {
 		data[k] = v
 	}
 	data["_context"] = context

--- a/pkg/janitor/rules_test.go
+++ b/pkg/janitor/rules_test.go
@@ -2,8 +2,9 @@ package janitor
 
 import (
 	"os"
-	"strings"
 	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestRuleValidation(t *testing.T) {
@@ -65,129 +66,95 @@ func TestRuleValidation(t *testing.T) {
 }
 
 func TestRuleMatches(t *testing.T) {
-	// Create a rule with a simpler JMESPath expression
-	rule := Rule{
-		ID:        "test-rule",
-		Resources: []string{"pods"},
-		JMESPath:  "metadata.labels.test == 'true'",
-		TTL:       "7d",
+	ingresses := ResourceType{
+		Group: "networking.k8s.io", Version: "v1",
+		Kind: "Ingress", Plural: "ingresses", Namespaced: true,
 	}
+	services := ResourceType{Version: "v1", Kind: "Service", Plural: "services", Namespaced: true}
 
-	// Manually compile the JMESPath expression
-	if err := rule.ValidateAndCompile(); err != nil {
-		t.Fatalf("Failed to compile rule: %v", err)
+	labelled := func(rt ResourceType, value string) Target {
+		return mustTarget(t, &unstructured.Unstructured{Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"name":      "x",
+				"namespace": "default",
+				"labels":    map[string]interface{}{"test": value},
+			},
+		}}, rt)
 	}
 
 	tests := []struct {
-		name     string
-		resource map[string]interface{}
-		context  map[string]interface{}
-		want     bool
+		name      string
+		resources []string
+		jmespath  string
+		target    Target
+		context   map[string]interface{}
+		want      bool
 	}{
 		{
-			name: "matching resource and context",
-			resource: map[string]interface{}{
-				"kind": "Pod",
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"test": "true",
-					},
-				},
-			},
-			context: map[string]interface{}{
-				"pvc_is_not_mounted": true,
-			},
-			want: true,
+			name:      "matching resource type and expression",
+			resources: []string{"pods"},
+			jmespath:  "metadata.labels.test == 'true'",
+			target:    labelled(podResourceType, "true"),
+			want:      true,
 		},
 		{
-			name: "non-matching resource type",
-			resource: map[string]interface{}{
-				"kind": "Service",
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"test": "true",
-					},
-				},
-			},
-			context: map[string]interface{}{
-				"pvc_is_not_mounted": true,
-			},
-			want: false,
+			name:      "non-matching resource type",
+			resources: []string{"pods"},
+			jmespath:  "metadata.labels.test == 'true'",
+			target:    labelled(services, "true"),
+			want:      false,
 		},
 		{
-			name: "non-matching label",
-			resource: map[string]interface{}{
-				"kind": "Pod",
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"test": "false",
-					},
-				},
-			},
-			context: map[string]interface{}{
-				"pvc_is_not_mounted": true,
-			},
-			want: false,
+			name:      "non-matching expression",
+			resources: []string{"pods"},
+			jmespath:  "metadata.labels.test == 'true'",
+			target:    labelled(podResourceType, "false"),
+			want:      false,
 		},
 		{
-			name: "non-matching context",
-			resource: map[string]interface{}{
-				"kind": "Pod",
-				"metadata": map[string]interface{}{
-					"labels": map[string]interface{}{
-						"test": "true",
-					},
-				},
-			},
-			context: map[string]interface{}{
-				"pvc_is_not_mounted": false,
-			},
-			want: true, // Changed to true since we removed the context check from JMESPath
+			name:      "star matches any resource type",
+			resources: []string{"*"},
+			jmespath:  "metadata.labels.test == 'true'",
+			target:    labelled(services, "true"),
+			want:      true,
+		},
+		{
+			// The plural comes from the listed Resource type, so a rule naming an
+			// irregular plural applies. Guessing it from the kind produced
+			// "ingresss", and such a rule never fired.
+			name:      "irregular plural",
+			resources: []string{"ingresses"},
+			jmespath:  "metadata.labels.test == 'true'",
+			target:    labelled(ingresses, "true"),
+			want:      true,
+		},
+		{
+			name:      "resource context is available to the expression",
+			resources: []string{"*"},
+			jmespath:  "_context.pvc_is_not_mounted",
+			target:    labelled(podResourceType, "true"),
+			context:   map[string]interface{}{"pvc_is_not_mounted": true},
+			want:      true,
+		},
+		{
+			name:      "resource context that does not hold",
+			resources: []string{"*"},
+			jmespath:  "_context.pvc_is_not_mounted",
+			target:    labelled(podResourceType, "true"),
+			context:   map[string]interface{}{"pvc_is_not_mounted": false},
+			want:      false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a custom Matches function for testing
-			matches := func(resource map[string]interface{}, context map[string]interface{}) bool {
-				// First check if resource type matches
-				kind, ok := resource["kind"].(string)
-				if !ok {
-					return false
-				}
-
-				resourceType := strings.ToLower(kind) + "s"
-
-				resourceMatches := false
-				for _, allowedResource := range rule.Resources {
-					if allowedResource == resourceType {
-						resourceMatches = true
-						break
-					}
-				}
-
-				if !resourceMatches {
-					return false
-				}
-
-				// Then evaluate JMESPath expression
-				if rule.compiledExpr != nil {
-					result, err := rule.compiledExpr.Search(resource)
-					if err != nil {
-						return false
-					}
-
-					if boolResult, ok := result.(bool); ok && boolResult {
-						return true
-					}
-				}
-
-				return false
+			rule := Rule{ID: "test-rule", Resources: tt.resources, JMESPath: tt.jmespath, TTL: "7d"}
+			if err := rule.ValidateAndCompile(); err != nil {
+				t.Fatalf("ValidateAndCompile() error = %v", err)
 			}
 
-			got := matches(tt.resource, tt.context)
-			if got != tt.want {
-				t.Errorf("Rule.Matches() = %v, want %v", got, tt.want)
+			if got := rule.Matches(tt.target, tt.context); got != tt.want {
+				t.Errorf("Matches() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/janitor/rules_test.go
+++ b/pkg/janitor/rules_test.go
@@ -66,10 +66,10 @@ func TestRuleValidation(t *testing.T) {
 }
 
 func TestRuleMatches(t *testing.T) {
-	ingresses := ResourceType{
-		Group: "networking.k8s.io", Version: "v1",
-		Kind: "Ingress", Plural: "ingresses", Namespaced: true,
-	}
+	// Held constant in every case whose axis is the resources list rather than the
+	// expression.
+	const labelIsTrue = "metadata.labels.test == 'true'"
+
 	services := ResourceType{Version: "v1", Kind: "Service", Plural: "services", Namespaced: true}
 
 	labelled := func(rt ResourceType, value string) Target {
@@ -93,28 +93,28 @@ func TestRuleMatches(t *testing.T) {
 		{
 			name:      "matching resource type and expression",
 			resources: []string{"pods"},
-			jmespath:  "metadata.labels.test == 'true'",
+			jmespath:  labelIsTrue,
 			target:    labelled(podResourceType, "true"),
 			want:      true,
 		},
 		{
 			name:      "non-matching resource type",
 			resources: []string{"pods"},
-			jmespath:  "metadata.labels.test == 'true'",
+			jmespath:  labelIsTrue,
 			target:    labelled(services, "true"),
 			want:      false,
 		},
 		{
 			name:      "non-matching expression",
 			resources: []string{"pods"},
-			jmespath:  "metadata.labels.test == 'true'",
+			jmespath:  labelIsTrue,
 			target:    labelled(podResourceType, "false"),
 			want:      false,
 		},
 		{
 			name:      "star matches any resource type",
 			resources: []string{"*"},
-			jmespath:  "metadata.labels.test == 'true'",
+			jmespath:  labelIsTrue,
 			target:    labelled(services, "true"),
 			want:      true,
 		},
@@ -124,8 +124,8 @@ func TestRuleMatches(t *testing.T) {
 			// "ingresss", and such a rule never fired.
 			name:      "irregular plural",
 			resources: []string{"ingresses"},
-			jmespath:  "metadata.labels.test == 'true'",
-			target:    labelled(ingresses, "true"),
+			jmespath:  labelIsTrue,
+			target:    labelled(ingressResourceType, "true"),
 			want:      true,
 		},
 		{

--- a/pkg/janitor/target.go
+++ b/pkg/janitor/target.go
@@ -29,11 +29,35 @@ type Target struct {
 	GVR schema.GroupVersionResource
 }
 
-// newTarget builds a target from a listed resource and the Resource type it was
-// listed as. The type is the only source of the kind, API version and GVR, so
-// nothing downstream re-derives them and no plural is ever guessed.
-func newTarget(obj metav1.Object, rt ResourceType) (Target, error) {
-	t := Target{
+// newTarget builds a target from a resource the dynamic client listed and the
+// Resource type it was listed as. The type is the only source of the kind, API
+// version and GVR, so nothing downstream re-derives them and no plural is ever
+// guessed. The caller must pass the type it listed the resource under; nothing
+// here can check that.
+func newTarget(u *unstructured.Unstructured, rt ResourceType) Target {
+	t := targetOf(u, rt)
+	t.Raw = u.Object
+	return t
+}
+
+// newTypedTarget builds a target from a resource the typed client returned,
+// converting it to the raw form rules evaluate against. Only namespaces take
+// this path, and only the conversion can fail.
+func newTypedTarget(obj metav1.Object, rt ResourceType) (Target, error) {
+	raw, err := toMap(obj)
+	if err != nil {
+		return Target{}, err
+	}
+
+	t := targetOf(obj, rt)
+	t.Raw = raw
+	return t, nil
+}
+
+// targetOf fills in everything that does not depend on how the resource was
+// listed.
+func targetOf(obj metav1.Object, rt ResourceType) Target {
+	return Target{
 		Kind:        rt.Kind,
 		APIVersion:  rt.apiVersion(),
 		Namespace:   obj.GetNamespace(),
@@ -43,21 +67,6 @@ func newTarget(obj metav1.Object, rt ResourceType) (Target, error) {
 		CreatedAt:   obj.GetCreationTimestamp().Time,
 		GVR:         rt.gvr(),
 	}
-
-	// Everything listed through the dynamic client already carries its raw form.
-	// Namespaces arrive from the typed client and have to be converted.
-	if u, ok := obj.(*unstructured.Unstructured); ok {
-		t.Raw = u.Object
-		return t, nil
-	}
-
-	raw, err := toMap(obj)
-	if err != nil {
-		return Target{}, err
-	}
-	t.Raw = raw
-
-	return t, nil
 }
 
 // toMap converts a Kubernetes object to a map for JMESPath evaluation.
@@ -73,6 +82,13 @@ func toMap(obj metav1.Object) (map[string]interface{}, error) {
 	}
 
 	return result, nil
+}
+
+// plural is the Resource type's plural: the name this target was listed under,
+// and the name the include and exclude lists and a rule's resources list name it
+// by.
+func (t Target) plural() string {
+	return t.GVR.Resource
 }
 
 // describe renders the target the way log messages and events refer to it.

--- a/pkg/janitor/target.go
+++ b/pkg/janitor/target.go
@@ -3,10 +3,8 @@ package janitor
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,57 +29,35 @@ type Target struct {
 	GVR schema.GroupVersionResource
 }
 
-// newTarget resolves a resource's kind, GVR and raw representation once, so that
-// nothing downstream has to assert on the concrete type again.
-func newTarget(obj metav1.Object) (Target, error) {
+// newTarget builds a target from a listed resource and the Resource type it was
+// listed as. The type is the only source of the kind, API version and GVR, so
+// nothing downstream re-derives them and no plural is ever guessed.
+func newTarget(obj metav1.Object, rt ResourceType) (Target, error) {
 	t := Target{
+		Kind:        rt.Kind,
+		APIVersion:  rt.apiVersion(),
 		Namespace:   obj.GetNamespace(),
 		Name:        obj.GetName(),
 		UID:         obj.GetUID(),
 		Annotations: obj.GetAnnotations(),
 		CreatedAt:   obj.GetCreationTimestamp().Time,
+		GVR:         rt.gvr(),
 	}
 
-	switch o := obj.(type) {
-	case *unstructured.Unstructured:
-		gvk := o.GroupVersionKind()
-		t.Kind = o.GetKind()
-		t.APIVersion = o.GetAPIVersion()
-		t.Raw = o.Object
-		t.GVR = schema.GroupVersionResource{
-			Group:    gvk.Group,
-			Version:  gvk.Version,
-			Resource: pluralize(gvk.Kind),
-		}
-	case *corev1.Namespace:
-		t.Kind = "Namespace"
-		t.APIVersion = "v1"
-		t.GVR = schema.GroupVersionResource{Version: "v1", Resource: "namespaces"}
-	default:
-		t.Kind = "Unknown"
-		t.APIVersion = "v1"
-		t.GVR = schema.GroupVersionResource{Version: "v1", Resource: pluralize("Unknown")}
+	// Everything listed through the dynamic client already carries its raw form.
+	// Namespaces arrive from the typed client and have to be converted.
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		t.Raw = u.Object
+		return t, nil
 	}
 
-	if t.Raw == nil {
-		raw, err := toMap(obj)
-		if err != nil {
-			return Target{}, err
-		}
-		t.Raw = raw
+	raw, err := toMap(obj)
+	if err != nil {
+		return Target{}, err
 	}
+	t.Raw = raw
 
 	return t, nil
-}
-
-// pluralize derives a plural resource name from a kind.
-//
-// This is wrong for irregular plurals: Ingress becomes "ingresss" and
-// NetworkPolicy becomes "networkpolicys". It reproduces what the code it replaced
-// did. The fix is to carry the GVR that listed the resource down to here instead
-// of guessing, which means building the target at list time.
-func pluralize(kind string) string {
-	return strings.ToLower(kind) + "s"
 }
 
 // toMap converts a Kubernetes object to a map for JMESPath evaluation.

--- a/pkg/janitor/target_test.go
+++ b/pkg/janitor/target_test.go
@@ -13,18 +13,33 @@ import (
 // The Resource types fixtures are listed as. ingressResourceType is the one the
 // irregular-plural cases turn on.
 var (
-	podResourceType        = ResourceType{Version: "v1", Kind: "Pod", Plural: "pods", Namespaced: true}
-	deploymentResourceType = ResourceType{Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true}
-	ingressResourceType    = ResourceType{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress", Plural: "ingresses", Namespaced: true}
+	podResourceType = ResourceType{
+		Version: "v1", Kind: "Pod", Plural: "pods", Namespaced: true,
+	}
+	deploymentResourceType = ResourceType{
+		Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true,
+	}
+	ingressResourceType = ResourceType{
+		Group: "networking.k8s.io", Version: "v1", Kind: "Ingress", Plural: "ingresses", Namespaced: true,
+	}
+	networkPolicyResourceType = ResourceType{
+		Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy",
+		Plural: "networkpolicies", Namespaced: true,
+	}
 )
 
-// mustTarget builds a Target for tests that drive the functions behind it.
+// mustTarget builds a Target for tests that drive the functions behind it,
+// taking either form a resource arrives in.
 func mustTarget(t *testing.T, obj metav1.Object, rt ResourceType) Target {
 	t.Helper()
 
-	target, err := newTarget(obj, rt)
+	if u, ok := obj.(*unstructured.Unstructured); ok {
+		return newTarget(u, rt)
+	}
+
+	target, err := newTypedTarget(obj, rt)
 	if err != nil {
-		t.Fatalf("newTarget() error = %v", err)
+		t.Fatalf("newTypedTarget() error = %v", err)
 	}
 	return target
 }
@@ -113,27 +128,55 @@ func TestNewTargetFromNamespace(t *testing.T) {
 
 // The listed Resource type is the only source of the plural, so irregular
 // plurals reach the Target intact. Guessing one from the kind is what this
-// replaced, and what these cases stop coming back.
+// replaced, and what these cases stop coming back. The wanted values are spelled
+// out rather than derived from the type, so that a fault in the derivation
+// itself fails here too.
 func TestNewTargetCarriesTheListedResourceType(t *testing.T) {
-	for _, rt := range []ResourceType{
-		ingressResourceType,
-		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy", Plural: "networkpolicies", Namespaced: true},
-	} {
-		t.Run(rt.Kind, func(t *testing.T) {
-			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+	tests := []struct {
+		rt             ResourceType
+		wantGVR        schema.GroupVersionResource
+		wantAPIVersion string
+	}{
+		{
+			rt: ingressResourceType,
+			wantGVR: schema.GroupVersionResource{
+				Group: "networking.k8s.io", Version: "v1", Resource: "ingresses",
+			},
+			wantAPIVersion: "networking.k8s.io/v1",
+		},
+		{
+			rt: networkPolicyResourceType,
+			wantGVR: schema.GroupVersionResource{
+				Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies",
+			},
+			wantAPIVersion: "networking.k8s.io/v1",
+		},
+		{
+			// A core-group type: the API version is the bare version, with no
+			// leading slash.
+			rt:             podResourceType,
+			wantGVR:        schema.GroupVersionResource{Version: "v1", Resource: "pods"},
+			wantAPIVersion: "v1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.rt.Kind, func(t *testing.T) {
+			got := newTarget(&unstructured.Unstructured{Object: map[string]interface{}{
 				"metadata": map[string]interface{}{"name": "x", "namespace": "default"},
-			}}
+			}}, tt.rt)
 
-			got := mustTarget(t, obj, rt)
-
-			if got.GVR != rt.gvr() {
-				t.Errorf("GVR = %v, want %v", got.GVR, rt.gvr())
+			if got.GVR != tt.wantGVR {
+				t.Errorf("GVR = %v, want %v", got.GVR, tt.wantGVR)
 			}
-			if got.Kind != rt.Kind {
-				t.Errorf("Kind = %q, want %q", got.Kind, rt.Kind)
+			if got.plural() != tt.wantGVR.Resource {
+				t.Errorf("plural() = %q, want %q", got.plural(), tt.wantGVR.Resource)
 			}
-			if got.APIVersion != rt.apiVersion() {
-				t.Errorf("APIVersion = %q, want %q", got.APIVersion, rt.apiVersion())
+			if got.Kind != tt.rt.Kind {
+				t.Errorf("Kind = %q, want %q", got.Kind, tt.rt.Kind)
+			}
+			if got.APIVersion != tt.wantAPIVersion {
+				t.Errorf("APIVersion = %q, want %q", got.APIVersion, tt.wantAPIVersion)
 			}
 		})
 	}
@@ -164,7 +207,8 @@ func TestTargetWasNotified(t *testing.T) {
 }
 
 func TestTargetDescribe(t *testing.T) {
-	target := mustTarget(t, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "pr-42"}}, namespaceResourceType)
+	target := mustTarget(t,
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "pr-42"}}, namespaceResourceType)
 
 	if got, want := target.describe(), "Namespace /pr-42"; got != want {
 		t.Errorf("describe() = %q, want %q", got, want)

--- a/pkg/janitor/target_test.go
+++ b/pkg/janitor/target_test.go
@@ -10,11 +10,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// podResourceType is the Resource type most fixtures are listed as.
+var podResourceType = ResourceType{Version: "v1", Kind: "Pod", Plural: "pods", Namespaced: true}
+
 // mustTarget builds a Target for tests that drive the functions behind it.
-func mustTarget(t *testing.T, obj metav1.Object) Target {
+func mustTarget(t *testing.T, obj metav1.Object, rt ResourceType) Target {
 	t.Helper()
 
-	target, err := newTarget(obj)
+	target, err := newTarget(obj, rt)
 	if err != nil {
 		t.Fatalf("newTarget() error = %v", err)
 	}
@@ -37,7 +40,9 @@ func TestNewTargetFromUnstructured(t *testing.T) {
 		},
 	}}
 
-	got := mustTarget(t, obj)
+	got := mustTarget(t, obj, ResourceType{
+		Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true,
+	})
 
 	if got.Kind != "Deployment" {
 		t.Errorf("Kind = %q, want %q", got.Kind, "Deployment")
@@ -72,7 +77,7 @@ func TestNewTargetFromUnstructured(t *testing.T) {
 func TestNewTargetFromNamespace(t *testing.T) {
 	got := mustTarget(t, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: "pr-42"},
-	})
+	}, namespaceResourceType)
 
 	// A namespace is its own name, and carries no namespace of its own.
 	if got.Kind != "Namespace" {
@@ -103,36 +108,32 @@ func TestNewTargetFromNamespace(t *testing.T) {
 	}
 }
 
-func TestNewTargetFromUnrecognisedType(t *testing.T) {
-	got := mustTarget(t, &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "one-off", Namespace: "default"},
-	})
-
-	if got.Kind != "Unknown" {
-		t.Errorf("Kind = %q, want Unknown", got.Kind)
-	}
-	if got.Raw == nil {
-		t.Error("Raw = nil, want the resource as a map")
-	}
-}
-
-// Pins behaviour that is known to be wrong, so that carrying the listed GVR down
-// to the target has to change it deliberately rather than by accident.
-func TestNewTargetGuessesPluralsAndGetsIrregularsWrong(t *testing.T) {
-	for kind, want := range map[string]string{
-		"Deployment":    "deployments",
-		"Ingress":       "ingresss",       // should be "ingresses"
-		"NetworkPolicy": "networkpolicys", // should be "networkpolicies"
+// The listed Resource type is the only source of the plural, so irregular
+// plurals reach the Target intact. Guessing one from the kind is what this
+// replaced, and what these cases stop coming back.
+func TestNewTargetCarriesTheListedResourceType(t *testing.T) {
+	for _, rt := range []ResourceType{
+		{Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress", Plural: "ingresses", Namespaced: true},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy", Plural: "networkpolicies", Namespaced: true},
 	} {
-		obj := &unstructured.Unstructured{Object: map[string]interface{}{
-			"kind":       kind,
-			"apiVersion": "v1",
-			"metadata":   map[string]interface{}{"name": "x", "namespace": "default"},
-		}}
+		t.Run(rt.Kind, func(t *testing.T) {
+			obj := &unstructured.Unstructured{Object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "x", "namespace": "default"},
+			}}
 
-		if got := mustTarget(t, obj).GVR.Resource; got != want {
-			t.Errorf("kind %s: GVR.Resource = %q, want %q", kind, got, want)
-		}
+			got := mustTarget(t, obj, rt)
+
+			if got.GVR != rt.gvr() {
+				t.Errorf("GVR = %v, want %v", got.GVR, rt.gvr())
+			}
+			if got.Kind != rt.Kind {
+				t.Errorf("Kind = %q, want %q", got.Kind, rt.Kind)
+			}
+			if got.APIVersion != rt.apiVersion() {
+				t.Errorf("APIVersion = %q, want %q", got.APIVersion, rt.apiVersion())
+			}
+		})
 	}
 }
 
@@ -151,7 +152,7 @@ func TestTargetWasNotified(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			target := mustTarget(t, &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "ns", Annotations: tt.annotations},
-			})
+			}, namespaceResourceType)
 
 			if got := target.wasNotified(); got != tt.want {
 				t.Errorf("wasNotified() = %v, want %v", got, tt.want)
@@ -161,7 +162,7 @@ func TestTargetWasNotified(t *testing.T) {
 }
 
 func TestTargetDescribe(t *testing.T) {
-	target := mustTarget(t, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "pr-42"}})
+	target := mustTarget(t, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "pr-42"}}, namespaceResourceType)
 
 	if got, want := target.describe(), "Namespace /pr-42"; got != want {
 		t.Errorf("describe() = %q, want %q", got, want)

--- a/pkg/janitor/target_test.go
+++ b/pkg/janitor/target_test.go
@@ -10,8 +10,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// podResourceType is the Resource type most fixtures are listed as.
-var podResourceType = ResourceType{Version: "v1", Kind: "Pod", Plural: "pods", Namespaced: true}
+// The Resource types fixtures are listed as. ingressResourceType is the one the
+// irregular-plural cases turn on.
+var (
+	podResourceType        = ResourceType{Version: "v1", Kind: "Pod", Plural: "pods", Namespaced: true}
+	deploymentResourceType = ResourceType{Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true}
+	ingressResourceType    = ResourceType{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress", Plural: "ingresses", Namespaced: true}
+)
 
 // mustTarget builds a Target for tests that drive the functions behind it.
 func mustTarget(t *testing.T, obj metav1.Object, rt ResourceType) Target {
@@ -40,9 +45,7 @@ func TestNewTargetFromUnstructured(t *testing.T) {
 		},
 	}}
 
-	got := mustTarget(t, obj, ResourceType{
-		Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true,
-	})
+	got := mustTarget(t, obj, deploymentResourceType)
 
 	if got.Kind != "Deployment" {
 		t.Errorf("Kind = %q, want %q", got.Kind, "Deployment")
@@ -113,8 +116,7 @@ func TestNewTargetFromNamespace(t *testing.T) {
 // replaced, and what these cases stop coming back.
 func TestNewTargetCarriesTheListedResourceType(t *testing.T) {
 	for _, rt := range []ResourceType{
-		{Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true},
-		{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress", Plural: "ingresses", Namespaced: true},
+		ingressResourceType,
 		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy", Plural: "networkpolicies", Namespaced: true},
 	} {
 		t.Run(rt.Kind, func(t *testing.T) {

--- a/pkg/janitor/verdict.go
+++ b/pkg/janitor/verdict.go
@@ -123,7 +123,7 @@ func decideFromRules(t Target, cfg *Config, now time.Time, resourceContext func(
 	}
 
 	for _, rule := range cfg.Rules {
-		if !rule.Matches(t.Raw, context) {
+		if !rule.Matches(t, context) {
 			continue
 		}
 

--- a/pkg/janitor/verdict_test.go
+++ b/pkg/janitor/verdict_test.go
@@ -285,7 +285,7 @@ func TestDecideAppliesRulesToUnannotatedResources(t *testing.T) {
 			"namespace":         "staging",
 			"creationTimestamp": now.Add(-2 * time.Hour).Format(time.RFC3339),
 		},
-	}}, ResourceType{Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true})
+	}}, deploymentResourceType)
 
 	if target.Annotations != nil {
 		t.Fatalf("Annotations = %v, want nil for this case to be meaningful", target.Annotations)

--- a/pkg/janitor/verdict_test.go
+++ b/pkg/janitor/verdict_test.go
@@ -304,12 +304,11 @@ func TestDecideAppliesRulesToUnannotatedResources(t *testing.T) {
 	}
 }
 
-// Pins a pre-existing defect this refactor does not fix. Namespaces are listed
-// through the typed client, which leaves TypeMeta empty, so the raw resource
-// carries no "kind" and Rule.Matches rejects it before evaluating any JMESPath.
-// Rules therefore never match namespaces, which makes the
-// temporary-pr-namespaces example in deploy/rules.yaml a no-op.
-func TestDecideNeverMatchesRulesAgainstNamespaces(t *testing.T) {
+// Namespaces are listed through the typed client, which leaves TypeMeta empty.
+// Matching on the raw resource's "kind" therefore rejected every namespace before
+// any JMESPath ran, which made the temporary-pr-namespaces example in
+// deploy/rules.yaml a no-op. Matching on the listed plural fixes it.
+func TestDecideMatchesRulesAgainstNamespaces(t *testing.T) {
 	target := mustTarget(t, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "pr-42",
@@ -317,18 +316,19 @@ func TestDecideNeverMatchesRulesAgainstNamespaces(t *testing.T) {
 		},
 	}, namespaceResourceType)
 
-	cfg := &Config{Rules: mustRules(t, Rule{
-		ID: "temporary-pr-namespaces", Resources: []string{"*"},
-		JMESPath: "metadata.name", TTL: "1h",
-	})}
+	for _, resources := range [][]string{{"*"}, {"namespaces"}} {
+		cfg := &Config{Rules: mustRules(t, Rule{
+			ID: "temporary-pr-namespaces", Resources: resources,
+			JMESPath: "starts_with(metadata.name, 'pr-')", TTL: "1h",
+		})}
 
-	got, err := Decide(target, cfg, now, nil)
-	if err != nil {
-		t.Fatalf("Decide() error = %v", err)
-	}
-	if got.Action != ActionNone {
-		t.Errorf("Action = %v, want %v -- if this now deletes, the defect is fixed "+
-			"and this test should assert the new behaviour", got.Action, ActionNone)
+		got, err := Decide(target, cfg, now, nil)
+		if err != nil {
+			t.Fatalf("Decide() error = %v", err)
+		}
+		if got.Action != ActionDelete {
+			t.Errorf("resources %v: Action = %v, want %v", resources, got.Action, ActionDelete)
+		}
 	}
 }
 

--- a/pkg/janitor/verdict_test.go
+++ b/pkg/janitor/verdict_test.go
@@ -35,7 +35,7 @@ func podObject(namespace, name string, age time.Duration, annotations map[string
 func pod(t *testing.T, age time.Duration, annotations map[string]string) Target {
 	t.Helper()
 
-	return mustTarget(t, podObject("staging", "web", age, annotations))
+	return mustTarget(t, podObject("staging", "web", age, annotations), podResourceType)
 }
 
 func toStringMap(in map[string]string) map[string]interface{} {
@@ -285,7 +285,7 @@ func TestDecideAppliesRulesToUnannotatedResources(t *testing.T) {
 			"namespace":         "staging",
 			"creationTimestamp": now.Add(-2 * time.Hour).Format(time.RFC3339),
 		},
-	}})
+	}}, ResourceType{Group: "apps", Version: "v1", Kind: "Deployment", Plural: "deployments", Namespaced: true})
 
 	if target.Annotations != nil {
 		t.Fatalf("Annotations = %v, want nil for this case to be meaningful", target.Annotations)
@@ -315,7 +315,7 @@ func TestDecideNeverMatchesRulesAgainstNamespaces(t *testing.T) {
 			Name:              "pr-42",
 			CreationTimestamp: metav1.Time{Time: now.Add(-2 * time.Hour)},
 		},
-	})
+	}, namespaceResourceType)
 
 	cfg := &Config{Rules: mustRules(t, Rule{
 		ID: "temporary-pr-namespaces", Resources: []string{"*"},


### PR DESCRIPTION
A Target's GVR was derived by lowercasing the kind and appending `s`. That is wrong for
every irregular plural: Ingress became `ingresss`, NetworkPolicy `networkpolicys`. The
listing code knew the real plural from discovery and discarded it, converting to
`[]metav1.Object`, which cannot hold one.

`newTarget` now takes the `ResourceType` the resource was listed as, and that type is the
only source of the kind, API version and GVR. `listNamespacedResources` and
`listClusterResources` collapse into `listTargets`, which returns Targets directly.
Namespaces come from the typed client, so they are handed a fixed `ResourceType` at the
call site and built by `newTypedTarget`, the one path where the conversion to a raw map
can fail.

`Rule.Matches` takes the Target and matches a rule's `resources` list against the plural
the Target was listed as, instead of deriving its own.

## Behaviour changes

- `--include-resources=ingresses` and `--exclude-resources=ingresses` now match. Deletes
  are no longer issued against resource names the API server does not have.
- Rules naming an irregular plural now fire.
- Rules now match namespaces. Namespaces are listed through the typed client, which leaves
  `TypeMeta` empty, so matching on the raw resource's `kind` rejected every namespace before
  any JMESPath ran. This made the `temporary-pr-namespaces` example in `deploy/rules.yaml`
  a no-op. A `resources: ["*"]` rule now applies to namespaces, which it did not before.
- Kubernetes events carry a correct `involvedObject.apiVersion`. The old code formatted it
  as `group/version` unconditionally, producing `/v1` for core resources.
- Configuration written against the old misspellings (`ingresss`, `networkpolicys`) no
  longer matches anything and must be corrected. There is no compatibility shim. The README
  says so, and points at `kubectl api-resources`.

## Tests

`TestNewTargetCarriesTheListedResourceType` spells out the wanted GVR, plural and API
version rather than deriving them, so a fault in the derivation fails it too.
`newRunFixture` takes a resource type, and `TestCleanUpDeletesAnIrregularlyPluralisedResource`
covers discovery through filtering, rule matching and deletion for an Ingress.
`TestRuleMatches` previously reimplemented `Matches` as a local closure and asserted against
the copy; it now drives `Matches` itself and covers irregular plurals and `_context`
injection.

Each assertion was checked by reintroducing the defect it guards: dropping the carried type
fails 6 tests, faulting `gvr()` fails 5, reverting the rule plural fails 4.

`CONTEXT.md` gains a **Resource type** entry. No ADR is affected; nothing here changes how a
Deadline is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)