### PR TITLE
Build the Config in one call, and make --log-format work

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -67,6 +67,14 @@ Resource context and events need, and the dynamic client for the arbitrary kinds
 a run lists and deletes. Both are resolved from one set of credentials.
 _Avoid_: Client, clientset, connection pool
 
+**Log line**:
+One thing a run says it did, carrying a level — whether it is a diagnostic, the
+ordinary course of the run, something worked around, or something that could not
+be done. The Configuration names the shape a line is written in and the levels
+worth writing; nothing that emits one decides whether it is wanted.
+_Avoid_: Message (a Notification's wording is a message; a Log line is not),
+output, trace
+
 **Notification**:
 A warning that a Target is about to be deleted, sent ahead of its Deadline.
 _Avoid_: Alert, message, event (a Notification may be recorded as a Kubernetes

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -48,6 +48,13 @@ A named condition that assigns a TTL to the Targets it matches, for resources th
 carry no annotation of their own.
 _Avoid_: Policy, matcher, filter
 
+**Configuration**:
+The settings one process runs under: what it considers, what it does when a
+Deadline passes, and the Rules it judges by. It is settled once, before the first
+run, and never changes while the process lives.
+_Avoid_: Options, settings, flags (flags are one of the things a Configuration is
+built from, not what it is)
+
 **Resource context**:
 Facts about a Target that cannot be read from the resource itself and must be
 looked up in the cluster, such as whether a volume claim is mounted. Rules may
@@ -90,3 +97,10 @@ The module that resolves the ambient credentials and returns the Cluster they
 grant. A run is handed a Cluster and never builds one, so the whole of a run can
 be exercised against fakes.
 _Avoid_: Client factory, bootstrap, initialise
+
+**Load**:
+The module that resolves the process's arguments and environment into a
+Configuration. What it hands back is complete, so nothing downstream has a
+half-built Configuration to finish. It is to the Configuration what Connect is
+to the Cluster.
+_Avoid_: Parse, init, setup

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -70,8 +70,8 @@ _Avoid_: Client, clientset, connection pool
 **Log line**:
 One thing a run says it did, carrying a level — whether it is a diagnostic, the
 ordinary course of the run, something worked around, or something that could not
-be done. The Configuration names the shape a line is written in and the levels
-worth writing; nothing that emits one decides whether it is wanted.
+be done. The Configuration names the shape a line is written in and the lowest
+level worth writing; nothing that emits one decides whether it is wanted.
 _Avoid_: Message (a Notification's wording is a message; a Log line is not),
 output, trace
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,13 @@ Namespaces are the one kind it considers without cluster resources being
 included.
 _Avoid_: Filter, matcher, scope
 
+**Report**:
+The module that writes Log lines. It is handed the shape and the lowest level
+the Configuration settled on, and is the only thing that decides whether a line
+is written; a run is handed one and never builds its own, so everything one
+process says goes out through the same place.
+_Avoid_: Logger (the name of the thing, not of the module), output, printer
+
 **Connect**:
 The module that resolves the ambient credentials and returns the Cluster they
 grant. A run is handed a Cluster and never builds one, so the whole of a run can

--- a/README.md
+++ b/README.md
@@ -112,15 +112,21 @@ Available command line options:
 
 `--debug`
 
-: Debug mode: print more information
+: Debug mode: also log `DEBUG` lines.
 
 `--quiet`
 
-: Quiet mode: Hides cleanup logs but keeps deletion logs
+: Quiet mode: log only `WARNING` and `ERROR` lines, so a run reports
+what went wrong and nothing else.
 
 `--log-format`
 
-: Set custom log format for structured logging output.
+: Set the format of each log line (default:
+`%(asctime)s %(levelname)s: %(message)s`). The placeholders are
+`%(asctime)s` (local time), `%(created)s` (Unix timestamp),
+`%(levelname)s` (`DEBUG`, `INFO`, `WARNING` or `ERROR`), `%(name)s`
+(`kube-janitor`) and `%(message)s`. Write `%%` for a literal percent
+sign. A format naming any other placeholder is refused at startup.
 
 `--once`
 
@@ -187,13 +193,14 @@ you want the resources to not be cleaned up if they\'ve been
 recently redeployed, and your deployment tooling can set this
 annotation.
 
-`--resource-context-hook`
+`RESOURCE_CONTEXT_HOOK`
 
-: Optional: string pointing to a Go function to populate the
-`_context` object with additional information, e.g. by calling
-external services. Built-in example to set `_context.random_dice` to
-a random dice value (1-6):
-`--resource-context-hook=hooks.RandomDice`.
+: Optional: environment variable naming a built-in hook that
+populates the `_context` object with additional information, e.g. by
+calling external services. The one built-in hook is `random_dice`,
+which sets `_context.random_dice` to a random dice value (1-6):
+`RESOURCE_CONTEXT_HOOK=random_dice`. A name that matches no hook is
+refused at startup.
 
 `--include-cluster-resources`
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ run is diagnosed: `--debug` wins.
 (`kube-janitor`) and `%(message)s`. Write `%%` for a literal percent
 sign. A format naming any other placeholder is refused at startup.
 
-: A placeholder written between two double quotes is escaped as a
-string value, so a format that builds JSON keeps producing JSON even
-when a message quotes a namespace name.
+: A placeholder that falls inside a quoted string is escaped as a
+string value, wherever in the string it sits, so a format that builds
+JSON keeps producing JSON even when a message quotes a namespace name
+or carries a Windows path.
 
 `--once`
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ Available command line options:
 `--quiet`
 
 : Quiet mode: log only `WARNING` and `ERROR` lines, so a run reports
-what went wrong and nothing else.
+what went wrong and nothing else. Given together with `--debug`, the
+run is diagnosed: `--debug` wins.
 
 `--log-format`
 
@@ -127,6 +128,10 @@ what went wrong and nothing else.
 `%(levelname)s` (`DEBUG`, `INFO`, `WARNING` or `ERROR`), `%(name)s`
 (`kube-janitor`) and `%(message)s`. Write `%%` for a literal percent
 sign. A format naming any other placeholder is refused at startup.
+
+: A placeholder written between two double quotes is escaped as a
+string value, so a format that builds JSON keeps producing JSON even
+when a message quotes a namespace name.
 
 `--once`
 

--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -61,7 +61,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	j := janitor.New(config, cluster)
+	j := janitor.New(config, cluster, logger)
 
 	// Set up context with cancellation and signal handling
 	ctx, gs := shutdown.ShutdownWithContext()

--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"log"
 	"os"
@@ -8,7 +9,6 @@ import (
 	"time"
 
 	"github.com/dschaaff/kube-janitor/pkg/janitor"
-	"github.com/dschaaff/kube-janitor/pkg/janitor/hooks"
 	"github.com/dschaaff/kube-janitor/pkg/janitor/shutdown"
 )
 
@@ -22,13 +22,13 @@ func main() {
 	log.Printf("Kubernetes Janitor %s (built: %s, commit: %s) starting up...",
 		version, buildDate, gitCommit)
 
-	config := janitor.NewConfig()
-	config.AddFlags(flag.CommandLine)
-
-	flag.Parse() // Parse flags after they've been added to flag.CommandLine
-
-	// Parse the comma-separated string flags after flag.Parse()
-	config.ParseStringFlags()
+	config, err := janitor.LoadConfig(os.Args[1:], os.Getenv)
+	if err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return
+		}
+		log.Fatalf("Invalid configuration: %v", err)
+	}
 
 	if config.Debug {
 		log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -51,25 +51,6 @@ func main() {
 		}
 	} else {
 		log.Printf("Using KUBECONFIG from environment: %s", os.Getenv("KUBECONFIG"))
-	}
-
-	if err := config.Validate(); err != nil {
-		log.Fatalf("Invalid configuration: %v", err)
-	}
-
-	if hookName := os.Getenv("RESOURCE_CONTEXT_HOOK"); hookName != "" {
-		hookFunc, err := hooks.GetHook(hookName)
-		if err != nil {
-			log.Fatalf("Failed to get hook: %v", err)
-		}
-		// Convert hooks.ResourceContextHook to janitor.ResourceContextHook
-		config.ResourceContextHook = func(resource interface{}, cache map[string]interface{}) map[string]interface{} {
-			return hookFunc(resource, cache)
-		}
-	}
-
-	if err := config.LoadRules(); err != nil {
-		log.Fatalf("Failed to load rules: %v", err)
 	}
 
 	cluster, err := janitor.Connect()
@@ -113,5 +94,3 @@ func main() {
 		}
 	}
 }
-
-// getEnvOrDefault moved to pkg/janitor/config.go

--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -19,9 +19,10 @@ var (
 )
 
 func main() {
-	log.Printf("Kubernetes Janitor %s (built: %s, commit: %s) starting up...",
-		version, buildDate, gitCommit)
-
+	// The configuration decides how a log line is formatted, so nothing is
+	// logged in the janitor's own format until it has loaded. A configuration
+	// that will not load is reported through the standard logger and is the one
+	// message a run can emit in another shape.
 	config, err := janitor.LoadConfig(os.Args[1:], os.Getenv)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
@@ -30,12 +31,13 @@ func main() {
 		log.Fatalf("Invalid configuration: %v", err)
 	}
 
-	if config.Debug {
-		log.SetFlags(log.LstdFlags | log.Lshortfile)
-	}
+	logger := janitor.NewLogger(config, os.Stderr)
+
+	logger.Infof("Kubernetes Janitor %s (built: %s, commit: %s) starting up...",
+		version, buildDate, gitCommit)
 
 	if config.DryRun {
-		log.Println("Running in dry-run mode")
+		logger.Infof("Running in dry-run mode")
 	}
 
 	// Check for KUBECONFIG environment variable
@@ -44,18 +46,19 @@ func main() {
 		if err == nil {
 			defaultKubeconfig := filepath.Join(homeDir, ".kube", "config")
 			if _, err := os.Stat(defaultKubeconfig); err == nil {
-				log.Printf("KUBECONFIG not set, using default: %s", defaultKubeconfig)
+				logger.Infof("KUBECONFIG not set, using default: %s", defaultKubeconfig)
 			} else {
-				log.Printf("Warning: KUBECONFIG not set and default config not found at %s", defaultKubeconfig)
+				logger.Warnf("KUBECONFIG not set and default config not found at %s", defaultKubeconfig)
 			}
 		}
 	} else {
-		log.Printf("Using KUBECONFIG from environment: %s", os.Getenv("KUBECONFIG"))
+		logger.Infof("Using KUBECONFIG from environment: %s", os.Getenv("KUBECONFIG"))
 	}
 
 	cluster, err := janitor.Connect()
 	if err != nil {
-		log.Fatalf("Failed to connect to cluster: %v", err)
+		logger.Errorf("Failed to connect to cluster: %v", err)
+		os.Exit(1)
 	}
 
 	j := janitor.New(config, cluster)
@@ -69,10 +72,10 @@ func main() {
 	if config.Once {
 		startTime := time.Now()
 		if err := j.CleanUp(ctx); err != nil {
-			log.Printf("Error during cleanup: %v", err)
+			logger.Errorf("Error during cleanup: %v", err)
 			os.Exit(1)
 		}
-		log.Printf("Cleanup completed in %v", time.Since(startTime))
+		logger.Infof("Cleanup completed in %v", time.Since(startTime))
 		return
 	}
 
@@ -87,9 +90,9 @@ func main() {
 		case <-ticker.C:
 			startTime := time.Now()
 			if err := j.CleanUp(ctx); err != nil {
-				log.Printf("Error during cleanup: %v", err)
+				logger.Errorf("Error during cleanup: %v", err)
 			} else {
-				log.Printf("Cleanup completed in %v", time.Since(startTime))
+				logger.Infof("Cleanup completed in %v", time.Since(startTime))
 			}
 		}
 	}

--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"errors"
 	"flag"
-	"log"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -21,14 +21,17 @@ var (
 func main() {
 	// The configuration decides how a log line is formatted, so nothing is
 	// logged in the janitor's own format until it has loaded. A configuration
-	// that will not load is reported through the standard logger and is the one
-	// message a run can emit in another shape.
+	// that will not load is reported plainly, once, and is the one message a
+	// run can emit in another shape.
 	config, err := janitor.LoadConfig(os.Args[1:], os.Getenv)
 	if err != nil {
 		if errors.Is(err, flag.ErrHelp) {
+			janitor.Usage(os.Stdout, os.Getenv)
 			return
 		}
-		log.Fatalf("Invalid configuration: %v", err)
+		fmt.Fprintf(os.Stderr, "kube-janitor: %v\n", err)
+		fmt.Fprintln(os.Stderr, "Run kube-janitor -help for the options a run accepts.")
+		os.Exit(1)
 	}
 
 	logger := janitor.NewLogger(config, os.Stderr)

--- a/pkg/janitor/config.go
+++ b/pkg/janitor/config.go
@@ -10,6 +10,10 @@ import (
 	"github.com/dschaaff/kube-janitor/pkg/janitor/hooks"
 )
 
+// programName is what the janitor calls itself in its usage text and its log
+// lines.
+const programName = "kube-janitor"
+
 const (
 	defaultInterval  = 30
 	defaultLogFormat = "%(asctime)s %(levelname)s: %(message)s"
@@ -75,12 +79,8 @@ func newConfig() *Config {
 // caller reports the trouble once, in the place it chooses. Whatever the
 // environment holds, arguments that only asked for usage get usage.
 func LoadConfig(args []string, env func(string) string) (*Config, error) {
-	c := newConfig()
-	c.applyEnv(env)
-
-	fs := flag.NewFlagSet("kube-janitor", flag.ContinueOnError)
+	c, fs := newFlagSet(env)
 	fs.SetOutput(io.Discard)
-	c.addFlags(fs)
 
 	if err := fs.Parse(args); err != nil {
 		return nil, err
@@ -105,14 +105,24 @@ func LoadConfig(args []string, env func(string) string) (*Config, error) {
 // take from this environment. Asking for usage is not a failure, so a caller
 // puts it where its output goes rather than where its errors do.
 func Usage(w io.Writer, env func(string) string) {
+	_, fs := newFlagSet(env)
+	fs.SetOutput(w)
+
+	fs.Usage()
+}
+
+// newFlagSet builds the flags a run is parsed from, over the defaults this
+// environment gives them. Loading a Configuration and printing the options both
+// go through it, so what usage says a run would do cannot drift from what it
+// does.
+func newFlagSet(env func(string) string) (*Config, *flag.FlagSet) {
 	c := newConfig()
 	c.applyEnv(env)
 
-	fs := flag.NewFlagSet("kube-janitor", flag.ContinueOnError)
-	fs.SetOutput(w)
+	fs := flag.NewFlagSet(programName, flag.ContinueOnError)
 	c.addFlags(fs)
 
-	fs.Usage()
+	return c, fs
 }
 
 // applyEnv folds the environment into the defaults before the flags are
@@ -228,6 +238,20 @@ func (c *Config) validate() error {
 	}
 
 	return nil
+}
+
+// lowestLogLevel works out the least a run reports. Asking for a diagnosis
+// beats asking for quiet: a run given both is being diagnosed, and a diagnosis
+// that left out the ordinary course of the run would be a poor one.
+func (c *Config) lowestLogLevel() logLevel {
+	switch {
+	case c.Debug:
+		return levelDebug
+	case c.Quiet:
+		return levelWarning
+	default:
+		return levelInfo
+	}
 }
 
 // loadRules reads the rules file, if one was named. A file that cannot be read

--- a/pkg/janitor/config.go
+++ b/pkg/janitor/config.go
@@ -3,6 +3,7 @@ package janitor
 import (
 	"flag"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -69,13 +70,16 @@ func newConfig() *Config {
 // resource context hook its settings name. It returns flag.ErrHelp when the
 // arguments asked for usage, which a caller reports as success rather than as a
 // bad configuration.
+//
+// Every failure comes back as an error and nothing is written anywhere, so the
+// caller reports the trouble once, in the place it chooses. Whatever the
+// environment holds, arguments that only asked for usage get usage.
 func LoadConfig(args []string, env func(string) string) (*Config, error) {
 	c := newConfig()
-	if err := c.applyEnv(env); err != nil {
-		return nil, err
-	}
+	c.applyEnv(env)
 
 	fs := flag.NewFlagSet("kube-janitor", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
 	c.addFlags(fs)
 
 	if err := fs.Parse(args); err != nil {
@@ -86,6 +90,10 @@ func LoadConfig(args []string, env func(string) string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := c.resolveHook(env("RESOURCE_CONTEXT_HOOK")); err != nil {
+		return nil, err
+	}
+
 	if err := c.loadRules(); err != nil {
 		return nil, err
 	}
@@ -93,12 +101,30 @@ func LoadConfig(args []string, env func(string) string) (*Config, error) {
 	return c, nil
 }
 
+// Usage writes the options a run accepts to w, each with the default it would
+// take from this environment. Asking for usage is not a failure, so a caller
+// puts it where its output goes rather than where its errors do.
+func Usage(w io.Writer, env func(string) string) {
+	c := newConfig()
+	c.applyEnv(env)
+
+	fs := flag.NewFlagSet("kube-janitor", flag.ContinueOnError)
+	fs.SetOutput(w)
+	c.addFlags(fs)
+
+	fs.Usage()
+}
+
 // applyEnv folds the environment into the defaults before the flags are
 // registered, so every flag's default is the value the run would use had the
 // flag been left out — which is also what usage prints. A variable that is
 // unset or empty leaves the default alone, which is how a container image
 // unsets one it inherited.
-func (c *Config) applyEnv(env func(string) string) error {
+//
+// Nothing here can fail: it only decides what a flag's default is. The settings
+// the environment names that could be wrong are resolved after the arguments
+// are parsed, so a run that only asked for usage still gets it.
+func (c *Config) applyEnv(env func(string) string) {
 	list := func(key string, target *[]string) {
 		if value := env(key); value != "" {
 			*target = splitList(value)
@@ -113,15 +139,22 @@ func (c *Config) applyEnv(env func(string) string) error {
 	if value := env("RULES_FILE"); value != "" {
 		c.RulesFile = value
 	}
+}
 
-	if name := env("RESOURCE_CONTEXT_HOOK"); name != "" {
-		hook, err := hooks.GetHook(name)
-		if err != nil {
-			return fmt.Errorf("failed to get hook: %v", err)
-		}
-		c.ResourceContextHook = ResourceContextHook(hook)
+// resolveHook looks up the resource context hook the environment named, so that
+// a run is handed the hook it asked for and a name that names nothing is
+// refused before the first Listing rather than at the first Target.
+func (c *Config) resolveHook(name string) error {
+	if name == "" {
+		return nil
 	}
 
+	hook, err := hooks.GetHook(name)
+	if err != nil {
+		return fmt.Errorf("failed to get resource context hook: %w", err)
+	}
+
+	c.ResourceContextHook = ResourceContextHook(hook)
 	return nil
 }
 
@@ -207,7 +240,7 @@ func (c *Config) loadRules() error {
 
 	rules, err := LoadRules(c.RulesFile)
 	if err != nil {
-		return fmt.Errorf("failed to load rules: %v", err)
+		return fmt.Errorf("failed to load rules: %w", err)
 	}
 
 	c.Rules = rules

--- a/pkg/janitor/config.go
+++ b/pkg/janitor/config.go
@@ -3,15 +3,20 @@ package janitor
 import (
 	"flag"
 	"fmt"
-	"os"
+	"slices"
 	"strings"
+
+	"github.com/dschaaff/kube-janitor/pkg/janitor/hooks"
 )
 
 const (
-	defaultExcludeResources  = "events,controllerrevisions,endpoints"
-	defaultExcludeNamespaces = "kube-system"
-	defaultInterval          = 30
-	defaultLogFormat         = "%(asctime)s %(levelname)s: %(message)s"
+	defaultInterval  = 30
+	defaultLogFormat = "%(asctime)s %(levelname)s: %(message)s"
+)
+
+var (
+	defaultExcludeResources  = []string{"events", "controllerrevisions", "endpoints"}
+	defaultExcludeNamespaces = []string{"kube-system"}
 )
 
 // Config holds all configuration options for the janitor
@@ -33,63 +38,146 @@ type Config struct {
 	IncludeClusterResources  bool
 	LogFormat                string
 
-	// Internal string fields for flag parsing
-	includeResourcesStr  string
-	excludeResourcesStr  string
-	includeNamespacesStr string
-	excludeNamespacesStr string
-
 	// Additional configuration
 	Rules               []Rule
 	ResourceContextHook ResourceContextHook
-	WebhookURL          string
 }
 
-// NewConfig creates a new Config with default values
-func NewConfig() *Config {
+// newConfig returns the configuration a run uses when nothing overrides it. It
+// is the only place a default is written down: the flags take theirs from the
+// Config this returns rather than declaring a second copy.
+func newConfig() *Config {
 	return &Config{
 		Interval:          defaultInterval,
 		LogFormat:         defaultLogFormat,
-		ExcludeResources:  strings.Split(defaultExcludeResources, ","),
-		ExcludeNamespaces: strings.Split(defaultExcludeNamespaces, ","),
+		ExcludeResources:  slices.Clone(defaultExcludeResources),
+		ExcludeNamespaces: slices.Clone(defaultExcludeNamespaces),
 		IncludeResources:  []string{"all"},
 		IncludeNamespaces: []string{"all"},
 	}
 }
 
-// AddFlags adds command line flags to parse configuration
-func (c *Config) AddFlags(fs *flag.FlagSet) {
-	fs.BoolVar(&c.DryRun, "dry-run", false, "Dry run mode: do not change anything, just print what would be done")
-	fs.BoolVar(&c.Debug, "debug", false, "Debug mode: print more information")
-	fs.BoolVar(&c.Quiet, "quiet", false, "Quiet mode: Hides cleanup logs but keeps deletion logs")
-	fs.BoolVar(&c.Once, "once", false, "Run only once and exit")
-	fs.IntVar(&c.Interval, "interval", defaultInterval, "Loop interval in seconds")
-	fs.IntVar(&c.WaitAfterDelete, "wait-after-delete", 0, "Wait time after issuing a delete (in seconds)")
-	fs.IntVar(&c.DeleteNotification, "delete-notification", 0, "Send an event seconds before to warn of the deletion")
+// LoadConfig builds the configuration for one process from its arguments and
+// its environment. It is the whole of construction, so no caller can get the
+// order wrong and nothing downstream is handed a half-built Config.
+//
+// env is the environment lookup, taken as an argument so a test needs no
+// ambient variables; a program passes os.Getenv. A flag beats the environment
+// variable for the same setting, which beats the default.
+//
+// The Config it returns is parsed, validated, and carries the Rules and the
+// resource context hook its settings name. It returns flag.ErrHelp when the
+// arguments asked for usage, which a caller reports as success rather than as a
+// bad configuration.
+func LoadConfig(args []string, env func(string) string) (*Config, error) {
+	c := newConfig()
+	if err := c.applyEnv(env); err != nil {
+		return nil, err
+	}
 
-	// Use custom variables to handle comma-separated lists
-	fs.StringVar(&c.includeResourcesStr, "include-resources", getEnvOrDefault("INCLUDE_RESOURCES", "all"), "Resources to consider for clean up (comma-separated)")
-	fs.StringVar(&c.excludeResourcesStr, "exclude-resources", getEnvOrDefault("EXCLUDE_RESOURCES", defaultExcludeResources), "Resources to exclude from clean up (comma-separated)")
-	fs.StringVar(&c.includeNamespacesStr, "include-namespaces", getEnvOrDefault("INCLUDE_NAMESPACES", "all"), "Include namespaces for clean up (comma-separated)")
-	fs.StringVar(&c.excludeNamespacesStr, "exclude-namespaces", getEnvOrDefault("EXCLUDE_NAMESPACES", defaultExcludeNamespaces), "Exclude namespaces from clean up (comma-separated)")
+	fs := flag.NewFlagSet("kube-janitor", flag.ContinueOnError)
+	c.addFlags(fs)
 
-	fs.StringVar(&c.RulesFile, "rules-file", os.Getenv("RULES_FILE"), "Load TTL rules from given file path")
-	fs.StringVar(&c.DeploymentTimeAnnotation, "deployment-time-annotation", "", "Annotation that contains a resource's last deployment time")
-	fs.BoolVar(&c.IncludeClusterResources, "include-cluster-resources", false, "Include cluster scoped resources")
-	fs.StringVar(&c.LogFormat, "log-format", defaultLogFormat, "Set custom log format")
+	if err := fs.Parse(args); err != nil {
+		return nil, err
+	}
+
+	if err := c.validate(); err != nil {
+		return nil, err
+	}
+
+	if err := c.loadRules(); err != nil {
+		return nil, err
+	}
+
+	return c, nil
 }
 
-// ParseStringFlags parses the comma-separated string flags into string slices
-// This must be called after flag.Parse()
-func (c *Config) ParseStringFlags() {
-	c.IncludeResources = strings.Split(c.includeResourcesStr, ",")
-	c.ExcludeResources = strings.Split(c.excludeResourcesStr, ",")
-	c.IncludeNamespaces = strings.Split(c.includeNamespacesStr, ",")
-	c.ExcludeNamespaces = strings.Split(c.excludeNamespacesStr, ",")
+// applyEnv folds the environment into the defaults before the flags are
+// registered, so every flag's default is the value the run would use had the
+// flag been left out — which is also what usage prints. A variable that is
+// unset or empty leaves the default alone, which is how a container image
+// unsets one it inherited.
+func (c *Config) applyEnv(env func(string) string) error {
+	list := func(key string, target *[]string) {
+		if value := env(key); value != "" {
+			*target = splitList(value)
+		}
+	}
+
+	list("INCLUDE_RESOURCES", &c.IncludeResources)
+	list("EXCLUDE_RESOURCES", &c.ExcludeResources)
+	list("INCLUDE_NAMESPACES", &c.IncludeNamespaces)
+	list("EXCLUDE_NAMESPACES", &c.ExcludeNamespaces)
+
+	if value := env("RULES_FILE"); value != "" {
+		c.RulesFile = value
+	}
+
+	if name := env("RESOURCE_CONTEXT_HOOK"); name != "" {
+		hook, err := hooks.GetHook(name)
+		if err != nil {
+			return fmt.Errorf("failed to get hook: %v", err)
+		}
+		c.ResourceContextHook = ResourceContextHook(hook)
+	}
+
+	return nil
 }
 
-// Validate checks if the configuration is valid
-func (c *Config) Validate() error {
+// addFlags registers each flag against the field it sets, taking its default
+// from the value that field already holds.
+func (c *Config) addFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&c.DryRun, "dry-run", c.DryRun, "Dry run mode: do not change anything, just print what would be done")
+	fs.BoolVar(&c.Debug, "debug", c.Debug, "Debug mode: print more information")
+	fs.BoolVar(&c.Quiet, "quiet", c.Quiet, "Quiet mode: Hides cleanup logs but keeps deletion logs")
+	fs.BoolVar(&c.Once, "once", c.Once, "Run only once and exit")
+	fs.IntVar(&c.Interval, "interval", c.Interval, "Loop interval in seconds")
+	fs.IntVar(&c.WaitAfterDelete, "wait-after-delete", c.WaitAfterDelete, "Wait time after issuing a delete (in seconds)")
+	fs.IntVar(&c.DeleteNotification, "delete-notification", c.DeleteNotification, "Send an event seconds before to warn of the deletion")
+
+	fs.Var(stringList{&c.IncludeResources}, "include-resources", "Resources to consider for clean up (comma-separated)")
+	fs.Var(stringList{&c.ExcludeResources}, "exclude-resources", "Resources to exclude from clean up (comma-separated)")
+	fs.Var(stringList{&c.IncludeNamespaces}, "include-namespaces", "Include namespaces for clean up (comma-separated)")
+	fs.Var(stringList{&c.ExcludeNamespaces}, "exclude-namespaces", "Exclude namespaces from clean up (comma-separated)")
+
+	fs.StringVar(&c.RulesFile, "rules-file", c.RulesFile, "Load TTL rules from given file path")
+	fs.StringVar(&c.DeploymentTimeAnnotation, "deployment-time-annotation", c.DeploymentTimeAnnotation, "Annotation that contains a resource's last deployment time")
+	fs.BoolVar(&c.IncludeClusterResources, "include-cluster-resources", c.IncludeClusterResources, "Include cluster scoped resources")
+	fs.StringVar(&c.LogFormat, "log-format", c.LogFormat, "Set custom log format")
+}
+
+// splitList reads a comma-separated list. It is the one place that decides what
+// separates two names, so a flag and the environment variable beside it cannot
+// disagree about what a list is.
+func splitList(value string) []string {
+	return strings.Split(value, ",")
+}
+
+// stringList is a comma-separated flag that splits straight into the field it
+// sets. A parsed FlagSet is therefore a finished Config, with no second step to
+// forget.
+type stringList struct {
+	target *[]string
+}
+
+// String renders the list the way usage prints a default. The flag package also
+// calls this on a zero stringList to work out whether a flag has a default
+// worth printing, so it has to tolerate a nil target.
+func (l stringList) String() string {
+	if l.target == nil {
+		return ""
+	}
+	return strings.Join(*l.target, ",")
+}
+
+func (l stringList) Set(value string) error {
+	*l.target = splitList(value)
+	return nil
+}
+
+// validate rejects the settings a run cannot work with.
+func (c *Config) validate() error {
 	if c.Interval < 1 {
 		return fmt.Errorf("interval must be greater than 0")
 	}
@@ -105,8 +193,10 @@ func (c *Config) Validate() error {
 	return nil
 }
 
-// LoadRules loads rules from the rules file if specified
-func (c *Config) LoadRules() error {
+// loadRules reads the rules file, if one was named. A file that cannot be read
+// or parsed stops the configuration from loading rather than leaving the run
+// with no rules and no complaint.
+func (c *Config) loadRules() error {
 	if c.RulesFile == "" {
 		return nil
 	}
@@ -118,11 +208,4 @@ func (c *Config) LoadRules() error {
 
 	c.Rules = rules
 	return nil
-}
-
-func getEnvOrDefault(key, defaultValue string) string {
-	if value := os.Getenv(key); value != "" {
-		return value
-	}
-	return defaultValue
 }

--- a/pkg/janitor/config.go
+++ b/pkg/janitor/config.go
@@ -129,8 +129,8 @@ func (c *Config) applyEnv(env func(string) string) error {
 // from the value that field already holds.
 func (c *Config) addFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&c.DryRun, "dry-run", c.DryRun, "Dry run mode: do not change anything, just print what would be done")
-	fs.BoolVar(&c.Debug, "debug", c.Debug, "Debug mode: print more information")
-	fs.BoolVar(&c.Quiet, "quiet", c.Quiet, "Quiet mode: Hides cleanup logs but keeps deletion logs")
+	fs.BoolVar(&c.Debug, "debug", c.Debug, "Debug mode: also log DEBUG lines")
+	fs.BoolVar(&c.Quiet, "quiet", c.Quiet, "Quiet mode: log only WARNING and ERROR lines")
 	fs.BoolVar(&c.Once, "once", c.Once, "Run only once and exit")
 	fs.IntVar(&c.Interval, "interval", c.Interval, "Loop interval in seconds")
 	fs.IntVar(&c.WaitAfterDelete, "wait-after-delete", c.WaitAfterDelete, "Wait time after issuing a delete (in seconds)")
@@ -188,6 +188,10 @@ func (c *Config) validate() error {
 
 	if c.WaitAfterDelete < 0 {
 		return fmt.Errorf("wait-after-delete must be greater than or equal to 0")
+	}
+
+	if _, err := parseLogFormat(c.LogFormat); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/janitor/config_test.go
+++ b/pkg/janitor/config_test.go
@@ -312,10 +312,40 @@ func TestLoadConfigResolvesTheResourceContextHook(t *testing.T) {
 // Usage is not a bad configuration: a caller tells the two apart so that
 // -help exits successfully.
 func TestLoadConfigReportsAskingForUsage(t *testing.T) {
-	_, err := LoadConfig([]string{"-help"}, noEnv)
+	tests := []struct {
+		name string
+		env  map[string]string
+	}{
+		{name: "nothing in the environment"},
+		{
+			// Asking what the options are is answerable whatever the environment
+			// holds, so a variable that would sink a run must not sink -help.
+			name: "an environment that would not load",
+			env:  map[string]string{"RESOURCE_CONTEXT_HOOK": "nonesuch", "RULES_FILE": "/nowhere.yaml"},
+		},
+	}
 
-	if !errors.Is(err, flag.ErrHelp) {
-		t.Errorf("LoadConfig(-help) = %v, want flag.ErrHelp", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := LoadConfig([]string{"-help"}, envOf(tt.env)); !errors.Is(err, flag.ErrHelp) {
+				t.Errorf("LoadConfig(-help) = %v, want flag.ErrHelp", err)
+			}
+		})
+	}
+}
+
+// Usage prints the default each flag would actually take, so what a run is
+// told matches what it would do rather than what the source says.
+func TestUsageShowsTheDefaultsThisEnvironmentGives(t *testing.T) {
+	var out strings.Builder
+	Usage(&out, envOf(map[string]string{"EXCLUDE_NAMESPACES": "kube-system,kube-public"}))
+
+	printed := out.String()
+
+	for _, want := range []string{"-exclude-namespaces", "kube-system,kube-public", "-log-format", "-interval"} {
+		if !strings.Contains(printed, want) {
+			t.Errorf("usage does not mention %q:\n%s", want, printed)
+		}
 	}
 }
 

--- a/pkg/janitor/config_test.go
+++ b/pkg/janitor/config_test.go
@@ -1,120 +1,330 @@
 package janitor
 
 import (
+	"errors"
 	"flag"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
-func TestConfigFlagParsing(t *testing.T) {
+// LoadConfig takes its environment as an argument, so these cases state the
+// environment they mean and never touch the one the test process runs in.
+func envOf(vars map[string]string) func(string) string {
+	return func(key string) string { return vars[key] }
+}
+
+// noEnv is the environment a process gets when nothing is exported.
+func noEnv(string) string { return "" }
+
+func mustLoad(t *testing.T, args []string, env map[string]string) *Config {
+	t.Helper()
+
+	cfg, err := LoadConfig(args, envOf(env))
+	if err != nil {
+		t.Fatalf("LoadConfig(%v) returned %v", args, err)
+	}
+	return cfg
+}
+
+// TestLoadConfigDefaults pins the values a run uses when it is told nothing.
+// Every other case states only what it changes, so this is the one place the
+// defaults themselves are written down twice — deliberately, so that changing
+// one has to be meant.
+func TestLoadConfigDefaults(t *testing.T) {
+	cfg := mustLoad(t, nil, nil)
+
+	want := &Config{
+		Interval:          30,
+		LogFormat:         "%(asctime)s %(levelname)s: %(message)s",
+		IncludeResources:  []string{"all"},
+		ExcludeResources:  []string{"events", "controllerrevisions", "endpoints"},
+		IncludeNamespaces: []string{"all"},
+		ExcludeNamespaces: []string{"kube-system"},
+	}
+
+	if !reflect.DeepEqual(cfg, want) {
+		t.Errorf("LoadConfig with nothing given = %+v, want %+v", cfg, want)
+	}
+}
+
+// The defaults are package-level slices, so a Config must be given its own copy
+// rather than a view onto them: one process appending to its exclusions would
+// otherwise change what every later Config starts from.
+func TestLoadConfigDoesNotShareTheDefaultLists(t *testing.T) {
+	first := mustLoad(t, nil, nil)
+	first.ExcludeResources[0] = "changed"
+	first.ExcludeNamespaces[0] = "changed"
+
+	second := mustLoad(t, nil, nil)
+
+	if second.ExcludeResources[0] != "events" {
+		t.Errorf("ExcludeResources = %v, want the untouched default", second.ExcludeResources)
+	}
+	if second.ExcludeNamespaces[0] != "kube-system" {
+		t.Errorf("ExcludeNamespaces = %v, want the untouched default", second.ExcludeNamespaces)
+	}
+}
+
+// Each case states only the setting it is about: the rest of the Config must
+// come back untouched, which is what catches a flag that disturbs a field it
+// has no business in.
+func TestLoadConfig(t *testing.T) {
 	tests := []struct {
-		name                      string
-		args                      []string
-		expectedIncludeResources  []string
-		expectedExcludeResources  []string
-		expectedIncludeNamespaces []string
-		expectedExcludeNamespaces []string
+		name string
+		args []string
+		env  map[string]string
+		want func(*Config)
 	}{
 		{
-			name:                      "default flags",
-			args:                      []string{},
-			expectedIncludeResources:  []string{"all"},
-			expectedExcludeResources:  []string{"events", "controllerrevisions", "endpoints"},
-			expectedIncludeNamespaces: []string{"all"},
-			expectedExcludeNamespaces: []string{"kube-system"},
+			name: "resources included by flag",
+			args: []string{"-include-resources", "pods,services"},
+			want: func(c *Config) { c.IncludeResources = []string{"pods", "services"} },
 		},
 		{
-			name:                      "custom include resources",
-			args:                      []string{"-include-resources", "pods,services"},
-			expectedIncludeResources:  []string{"pods", "services"},
-			expectedExcludeResources:  []string{"events", "controllerrevisions", "endpoints"},
-			expectedIncludeNamespaces: []string{"all"},
-			expectedExcludeNamespaces: []string{"kube-system"},
+			name: "a single namespace included by flag",
+			args: []string{"-include-namespaces", "test-namespace"},
+			want: func(c *Config) { c.IncludeNamespaces = []string{"test-namespace"} },
 		},
 		{
-			name:                      "custom include namespaces",
-			args:                      []string{"-include-namespaces", "default,test"},
-			expectedIncludeResources:  []string{"all"},
-			expectedExcludeResources:  []string{"events", "controllerrevisions", "endpoints"},
-			expectedIncludeNamespaces: []string{"default", "test"},
-			expectedExcludeNamespaces: []string{"kube-system"},
+			name: "namespaces excluded by flag replace the default exclusion",
+			args: []string{"-exclude-namespaces", "kube-system,kube-public"},
+			want: func(c *Config) { c.ExcludeNamespaces = []string{"kube-system", "kube-public"} },
 		},
 		{
-			name:                      "custom exclude namespaces",
-			args:                      []string{"-exclude-namespaces", "kube-system,kube-public"},
-			expectedIncludeResources:  []string{"all"},
-			expectedExcludeResources:  []string{"events", "controllerrevisions", "endpoints"},
-			expectedIncludeNamespaces: []string{"all"},
-			expectedExcludeNamespaces: []string{"kube-system", "kube-public"},
+			name: "resources excluded by flag replace the default exclusion",
+			args: []string{"-exclude-resources", "events"},
+			want: func(c *Config) { c.ExcludeResources = []string{"events"} },
 		},
 		{
-			name:                      "single namespace include",
-			args:                      []string{"-include-namespaces", "test-namespace"},
-			expectedIncludeResources:  []string{"all"},
-			expectedExcludeResources:  []string{"events", "controllerrevisions", "endpoints"},
-			expectedIncludeNamespaces: []string{"test-namespace"},
-			expectedExcludeNamespaces: []string{"kube-system"},
+			// The README offers the environment as an alternative to the flags,
+			// which is how a deployment configures the janitor without arguments.
+			name: "every list set by the environment",
+			env: map[string]string{
+				"INCLUDE_RESOURCES":  "pods",
+				"EXCLUDE_RESOURCES":  "events",
+				"INCLUDE_NAMESPACES": "staging",
+				"EXCLUDE_NAMESPACES": "kube-system,kube-public",
+			},
+			want: func(c *Config) {
+				c.IncludeResources = []string{"pods"}
+				c.ExcludeResources = []string{"events"}
+				c.IncludeNamespaces = []string{"staging"}
+				c.ExcludeNamespaces = []string{"kube-system", "kube-public"}
+			},
+		},
+		{
+			name: "a flag beats the environment variable for the same list",
+			args: []string{"-include-resources", "deployments"},
+			env:  map[string]string{"INCLUDE_RESOURCES": "pods"},
+			want: func(c *Config) { c.IncludeResources = []string{"deployments"} },
+		},
+		{
+			// An empty variable is how a container image unsets one it inherited,
+			// and must not narrow the run to a list holding one empty name.
+			name: "an empty environment variable leaves the default alone",
+			env:  map[string]string{"INCLUDE_RESOURCES": "", "EXCLUDE_NAMESPACES": "", "RULES_FILE": ""},
+		},
+		{
+			name: "every switch turned on",
+			args: []string{"-dry-run", "-debug", "-quiet", "-once", "-include-cluster-resources"},
+			want: func(c *Config) {
+				c.DryRun, c.Debug, c.Quiet, c.Once, c.IncludeClusterResources = true, true, true, true, true
+			},
+		},
+		{
+			name: "the timings given",
+			args: []string{"-interval", "60", "-wait-after-delete", "5", "-delete-notification", "120"},
+			want: func(c *Config) { c.Interval, c.WaitAfterDelete, c.DeleteNotification = 60, 5, 120 },
+		},
+		{
+			name: "the annotation and log format given",
+			args: []string{"-deployment-time-annotation", "deployed-at", "-log-format", "json"},
+			want: func(c *Config) { c.DeploymentTimeAnnotation, c.LogFormat = "deployed-at", "json" },
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a new FlagSet for this test
-			fs := flag.NewFlagSet("test", flag.ContinueOnError)
-
-			// Create config and add flags
-			config := NewConfig()
-			config.AddFlags(fs)
-
-			// Parse the test arguments
-			if len(tt.args) > 0 {
-				err := fs.Parse(tt.args)
-				if err != nil {
-					t.Fatalf("Failed to parse flags: %v", err)
-				}
+			want := newConfig()
+			if tt.want != nil {
+				tt.want(want)
 			}
 
-			// Parse the string flags after flag parsing
-			config.ParseStringFlags()
-
-			// Check include resources
-			if len(config.IncludeResources) != len(tt.expectedIncludeResources) {
-				t.Errorf("Expected %d include resources, got %d", len(tt.expectedIncludeResources), len(config.IncludeResources))
-			}
-			for i, expected := range tt.expectedIncludeResources {
-				if i >= len(config.IncludeResources) || config.IncludeResources[i] != expected {
-					t.Errorf("Expected include resource %d to be %s, got %s", i, expected, config.IncludeResources[i])
-				}
-			}
-
-			// Check exclude resources
-			if len(config.ExcludeResources) != len(tt.expectedExcludeResources) {
-				t.Errorf("Expected %d exclude resources, got %d", len(tt.expectedExcludeResources), len(config.ExcludeResources))
-			}
-			for i, expected := range tt.expectedExcludeResources {
-				if i >= len(config.ExcludeResources) || config.ExcludeResources[i] != expected {
-					t.Errorf("Expected exclude resource %d to be %s, got %s", i, expected, config.ExcludeResources[i])
-				}
-			}
-
-			// Check include namespaces
-			if len(config.IncludeNamespaces) != len(tt.expectedIncludeNamespaces) {
-				t.Errorf("Expected %d include namespaces, got %d", len(tt.expectedIncludeNamespaces), len(config.IncludeNamespaces))
-			}
-			for i, expected := range tt.expectedIncludeNamespaces {
-				if i >= len(config.IncludeNamespaces) || config.IncludeNamespaces[i] != expected {
-					t.Errorf("Expected include namespace %d to be %s, got %s", i, expected, config.IncludeNamespaces[i])
-				}
-			}
-
-			// Check exclude namespaces
-			if len(config.ExcludeNamespaces) != len(tt.expectedExcludeNamespaces) {
-				t.Errorf("Expected %d exclude namespaces, got %d", len(tt.expectedExcludeNamespaces), len(config.ExcludeNamespaces))
-			}
-			for i, expected := range tt.expectedExcludeNamespaces {
-				if i >= len(config.ExcludeNamespaces) || config.ExcludeNamespaces[i] != expected {
-					t.Errorf("Expected exclude namespace %d to be %s, got %s", i, expected, config.ExcludeNamespaces[i])
-				}
+			if got := mustLoad(t, tt.args, tt.env); !reflect.DeepEqual(got, want) {
+				t.Errorf("LoadConfig(%v, %v) = %+v, want %+v", tt.args, tt.env, got, want)
 			}
 		})
 	}
+}
+
+// A Config that loads is a Config a run can work with, so the settings that
+// would make a run misbehave are refused here rather than later.
+func TestLoadConfigRefusesUnusableSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			// The interval drives a ticker, which panics on a period of zero.
+			name: "an interval of zero",
+			args: []string{"-interval", "0"},
+			want: "interval must be greater than 0",
+		},
+		{
+			name: "a negative interval",
+			args: []string{"-interval", "-1"},
+			want: "interval must be greater than 0",
+		},
+		{
+			name: "a negative notification window",
+			args: []string{"-delete-notification", "-1"},
+			want: "delete-notification must be greater than or equal to 0",
+		},
+		{
+			name: "a negative wait after delete",
+			args: []string{"-wait-after-delete", "-1"},
+			want: "wait-after-delete must be greater than or equal to 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := LoadConfig(tt.args, noEnv)
+
+			if err == nil {
+				t.Fatalf("LoadConfig(%v) returned a Config, want an error", tt.args)
+			}
+			if cfg != nil {
+				t.Errorf("LoadConfig(%v) returned a Config alongside its error", tt.args)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("LoadConfig(%v) = %v, want it to mention %q", tt.args, err, tt.want)
+			}
+		})
+	}
+}
+
+// The rules file is read while the configuration loads, so a run is handed
+// either its Rules or an error, and never an empty rule set it cannot explain.
+func TestLoadConfigReadsTheRulesFile(t *testing.T) {
+	path := writeRulesFile(t, `rules:
+- id: stale-pods
+  resources: ["pods"]
+  jmespath: "metadata.labels.test == 'true'"
+  ttl: "7d"
+`)
+
+	for _, tt := range []struct {
+		name string
+		args []string
+		env  map[string]string
+	}{
+		{name: "named by flag", args: []string{"-rules-file", path}},
+		{name: "named by the environment", env: map[string]string{"RULES_FILE": path}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := mustLoad(t, tt.args, tt.env)
+
+			if cfg.RulesFile != path {
+				t.Errorf("RulesFile = %q, want %q", cfg.RulesFile, path)
+			}
+			if len(cfg.Rules) != 1 || cfg.Rules[0].ID != "stale-pods" {
+				t.Fatalf("Rules = %+v, want the one rule the file holds", cfg.Rules)
+			}
+		})
+	}
+}
+
+func TestLoadConfigRefusesABadRulesFile(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "a file that is not there",
+			path: filepath.Join(t.TempDir(), "absent.yaml"),
+			want: "failed to read rules file",
+		},
+		{
+			name: "a file that is not the rules format",
+			path: writeRulesFile(t, "this: [is not: valid yaml"),
+			want: "failed to parse rules file",
+		},
+		{
+			name: "a rule the janitor cannot compile",
+			path: writeRulesFile(t, "rules:\n- id: broken\n  resources: [\"pods\"]\n  jmespath: \"???\"\n  ttl: \"7d\"\n"),
+			want: "invalid rule",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadConfig([]string{"-rules-file", tt.path}, noEnv)
+
+			if err == nil {
+				t.Fatalf("LoadConfig loaded %s, want an error", tt.path)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("LoadConfig(%s) = %v, want it to mention %q", tt.path, err, tt.want)
+			}
+		})
+	}
+}
+
+// The resource context hook is resolved while the configuration loads, for the
+// same reason the rules file is: a run is handed the hook it was told to use,
+// and a name that names nothing is refused here.
+func TestLoadConfigResolvesTheResourceContextHook(t *testing.T) {
+	t.Run("a hook the janitor knows", func(t *testing.T) {
+		cfg := mustLoad(t, nil, map[string]string{"RESOURCE_CONTEXT_HOOK": "random_dice"})
+
+		if cfg.ResourceContextHook == nil {
+			t.Fatal("ResourceContextHook is nil, want the hook the environment named")
+		}
+		if data := cfg.ResourceContextHook(nil, map[string]interface{}{}); len(data) == 0 {
+			t.Errorf("the hook returned %v, want it to contribute context", data)
+		}
+	})
+
+	t.Run("a hook the janitor does not know", func(t *testing.T) {
+		_, err := LoadConfig(nil, envOf(map[string]string{"RESOURCE_CONTEXT_HOOK": "nonesuch"}))
+
+		if err == nil {
+			t.Fatal("LoadConfig accepted an unknown hook, want an error")
+		}
+		if !strings.Contains(err.Error(), "nonesuch") {
+			t.Errorf("LoadConfig = %v, want it to name the hook it could not find", err)
+		}
+	})
+
+	t.Run("no hook named", func(t *testing.T) {
+		if cfg := mustLoad(t, nil, nil); cfg.ResourceContextHook != nil {
+			t.Error("ResourceContextHook is set, want nil when nothing named one")
+		}
+	})
+}
+
+// Usage is not a bad configuration: a caller tells the two apart so that
+// -help exits successfully.
+func TestLoadConfigReportsAskingForUsage(t *testing.T) {
+	_, err := LoadConfig([]string{"-help"}, noEnv)
+
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Errorf("LoadConfig(-help) = %v, want flag.ErrHelp", err)
+	}
+}
+
+func writeRulesFile(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "rules.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write the rules file: %v", err)
+	}
+	return path
 }

--- a/pkg/janitor/constants.go
+++ b/pkg/janitor/constants.go
@@ -8,9 +8,4 @@ const (
 
 	// Special TTL value
 	TTLUnlimited = "forever"
-
-	// Default values
-	DefaultInterval          = 30
-	DefaultExcludeResources  = "events,controllerrevisions"
-	DefaultExcludeNamespaces = "kube-system"
 )

--- a/pkg/janitor/context.go
+++ b/pkg/janitor/context.go
@@ -3,7 +3,6 @@ package janitor
 import (
 	"context"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 
@@ -56,7 +55,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 		for _, volume := range pod.Spec.Volumes {
 			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
 				isMounted = true
-				log.Printf("PVC %s/%s is mounted by pod %s", namespace, pvcName, pod.Name)
+				j.log.Debugf("PVC %s/%s is mounted by pod %s", namespace, pvcName, pod.Name)
 				break
 			}
 		}
@@ -78,12 +77,12 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 			pattern := fmt.Sprintf("^%s-%s-[0-9]+$", regexp.QuoteMeta(claimPrefix), regexp.QuoteMeta(sts.Name))
 			matched, err := regexp.MatchString(pattern, pvcName)
 			if err != nil {
-				log.Printf("Error matching PVC name pattern: %v", err)
+				j.log.Errorf("Error matching PVC name pattern: %v", err)
 				continue
 			}
 			if matched {
 				isReferenced = true
-				log.Printf("PVC %s/%s is referenced by StatefulSet %s", namespace, pvcName, sts.Name)
+				j.log.Debugf("PVC %s/%s is referenced by StatefulSet %s", namespace, pvcName, sts.Name)
 				break
 			}
 		}
@@ -96,7 +95,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 	if !isReferenced {
 		// Check Deployments
 		if referenced, err := j.isPVCReferencedByDeployments(ctx, namespace, pvcName); err != nil {
-			log.Printf("Error checking deployments: %v", err)
+			j.log.Errorf("Error checking deployments: %v", err)
 		} else if referenced {
 			isReferenced = true
 		}
@@ -104,7 +103,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 		// Check Jobs
 		if !isReferenced {
 			if referenced, err := j.isPVCReferencedByJobs(ctx, namespace, pvcName); err != nil {
-				log.Printf("Error checking jobs: %v", err)
+				j.log.Errorf("Error checking jobs: %v", err)
 			} else if referenced {
 				isReferenced = true
 			}
@@ -113,7 +112,7 @@ func (j *Janitor) getPVCContext(ctx context.Context, t Target) (*ResourceContext
 		// Check CronJobs
 		if !isReferenced {
 			if referenced, err := j.isPVCReferencedByCronJobs(ctx, namespace, pvcName); err != nil {
-				log.Printf("Error checking cronjobs: %v", err)
+				j.log.Errorf("Error checking cronjobs: %v", err)
 			} else if referenced {
 				isReferenced = true
 			}
@@ -136,7 +135,7 @@ func (j *Janitor) isPVCReferencedByDeployments(ctx context.Context, namespace, p
 	for _, deploy := range deployments.Items {
 		for _, volume := range deploy.Spec.Template.Spec.Volumes {
 			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
-				log.Printf("PVC %s/%s is referenced by Deployment %s", namespace, pvcName, deploy.Name)
+				j.log.Debugf("PVC %s/%s is referenced by Deployment %s", namespace, pvcName, deploy.Name)
 				return true, nil
 			}
 		}
@@ -153,7 +152,7 @@ func (j *Janitor) isPVCReferencedByJobs(ctx context.Context, namespace, pvcName 
 	for _, job := range jobs.Items {
 		for _, volume := range job.Spec.Template.Spec.Volumes {
 			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
-				log.Printf("PVC %s/%s is referenced by Job %s", namespace, pvcName, job.Name)
+				j.log.Debugf("PVC %s/%s is referenced by Job %s", namespace, pvcName, job.Name)
 				return true, nil
 			}
 		}
@@ -170,7 +169,7 @@ func (j *Janitor) isPVCReferencedByCronJobs(ctx context.Context, namespace, pvcN
 	for _, cronJob := range cronJobs.Items {
 		for _, volume := range cronJob.Spec.JobTemplate.Spec.Template.Spec.Volumes {
 			if volume.PersistentVolumeClaim != nil && volume.PersistentVolumeClaim.ClaimName == pvcName {
-				log.Printf("PVC %s/%s is referenced by CronJob %s", namespace, pvcName, cronJob.Name)
+				j.log.Debugf("PVC %s/%s is referenced by CronJob %s", namespace, pvcName, cronJob.Name)
 				return true, nil
 			}
 		}

--- a/pkg/janitor/context_test.go
+++ b/pkg/janitor/context_test.go
@@ -107,7 +107,8 @@ func TestGetPVCContext(t *testing.T) {
 			clientset := fake.NewSimpleClientset()
 
 			// Create janitor instance with fake client
-			j := New(&Config{}, Cluster{Typed: clientset}, NewLogger(&Config{}, io.Discard))
+			cfg := &Config{}
+			j := New(cfg, Cluster{Typed: clientset}, NewLogger(cfg, io.Discard))
 
 			// Create test resources in fake client
 			if tt.pvc != nil {

--- a/pkg/janitor/context_test.go
+++ b/pkg/janitor/context_test.go
@@ -2,6 +2,7 @@ package janitor
 
 import (
 	"context"
+	"io"
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -106,7 +107,7 @@ func TestGetPVCContext(t *testing.T) {
 			clientset := fake.NewSimpleClientset()
 
 			// Create janitor instance with fake client
-			j := New(&Config{}, Cluster{Typed: clientset})
+			j := New(&Config{}, Cluster{Typed: clientset}, NewLogger(&Config{}, io.Discard))
 
 			// Create test resources in fake client
 			if tt.pvc != nil {
@@ -177,7 +178,8 @@ func TestGetResourceContext(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j := New(&Config{ResourceContextHook: tt.hook}, Cluster{Typed: fake.NewSimpleClientset()})
+			cfg := &Config{ResourceContextHook: tt.hook}
+			j := New(cfg, Cluster{Typed: fake.NewSimpleClientset()}, NewLogger(cfg, io.Discard))
 
 			// Run setup if provided
 			if tt.setup != nil {

--- a/pkg/janitor/effects.go
+++ b/pkg/janitor/effects.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -37,8 +36,8 @@ func (j *Janitor) Apply(ctx context.Context, t Target, v Verdict, now time.Time)
 // notify warns that a target is about to be deleted.
 func (j *Janitor) notify(ctx context.Context, t Target, v Verdict, now time.Time) error {
 	if j.config.DryRun {
-		log.Printf("**DRY-RUN**: Would send delete notification for %s", t.describe())
-		j.debugLog("Notification: %s", v.Message)
+		j.log.Infof("**DRY-RUN**: Would send delete notification for %s", t.describe())
+		j.log.Debugf("Notification: %s", v.Message)
 		return nil
 	}
 
@@ -52,7 +51,7 @@ func (j *Janitor) notify(ctx context.Context, t Target, v Verdict, now time.Time
 	}
 
 	if err := SendWebhookNotification(message); err != nil {
-		log.Printf("Failed to send webhook notification: %v", err)
+		j.log.Warnf("Failed to send webhook notification: %v", err)
 	}
 
 	// Flags the target as notified for the rest of this run only. Nothing writes
@@ -69,7 +68,7 @@ func (j *Janitor) notify(ctx context.Context, t Target, v Verdict, now time.Time
 // createEvent records a Kubernetes event against the target.
 func (j *Janitor) createEvent(ctx context.Context, t Target, message, reason string, now time.Time) error {
 	if j.config.DryRun {
-		log.Printf("**DRY-RUN**: Would create event: %s", message)
+		j.log.Infof("**DRY-RUN**: Would create event: %s", message)
 		return nil
 	}
 
@@ -111,8 +110,8 @@ func (j *Janitor) createEvent(ctx context.Context, t Target, message, reason str
 
 func (j *Janitor) deleteResource(ctx context.Context, t Target) error {
 	if j.config.DryRun {
-		log.Printf("**DRY-RUN**: Would delete %s", t.describe())
-		j.debugLog("Resource would be deleted with propagation policy: Background")
+		j.log.Infof("**DRY-RUN**: Would delete %s", t.describe())
+		j.log.Debugf("Resource would be deleted with propagation policy: Background")
 		return nil
 	}
 
@@ -121,10 +120,10 @@ func (j *Janitor) deleteResource(ctx context.Context, t Target) error {
 
 	var err error
 	if t.Namespace != "" {
-		j.infoLog("Deleting namespaced resource %s/%s", t.Namespace, t.Name)
+		j.log.Infof("Deleting namespaced resource %s/%s", t.Namespace, t.Name)
 		err = j.cluster.Dynamic.Resource(t.GVR).Namespace(t.Namespace).Delete(ctx, t.Name, deleteOptions)
 	} else {
-		j.infoLog("Deleting cluster-scoped resource %s", t.Name)
+		j.log.Infof("Deleting cluster-scoped resource %s", t.Name)
 		err = j.cluster.Dynamic.Resource(t.GVR).Delete(ctx, t.Name, deleteOptions)
 	}
 	if err != nil {
@@ -132,7 +131,7 @@ func (j *Janitor) deleteResource(ctx context.Context, t Target) error {
 	}
 
 	if j.config.WaitAfterDelete > 0 {
-		j.infoLog("Waiting %d seconds after delete", j.config.WaitAfterDelete)
+		j.log.Infof("Waiting %d seconds after delete", j.config.WaitAfterDelete)
 		time.Sleep(time.Duration(j.config.WaitAfterDelete) * time.Second)
 	}
 

--- a/pkg/janitor/effects_test.go
+++ b/pkg/janitor/effects_test.go
@@ -28,7 +28,7 @@ func newEffectsFixture(t *testing.T, cfg *Config) effectsFixture {
 		janitor: New(cfg, Cluster{
 			Typed:   fake.NewSimpleClientset(),
 			Dynamic: dynamicClientFor([]ResourceType{podResourceType}, obj),
-		}),
+		}, NewLogger(cfg, io.Discard)),
 		target: mustTarget(t, obj, podResourceType),
 	}
 }

--- a/pkg/janitor/janitor.go
+++ b/pkg/janitor/janitor.go
@@ -3,7 +3,7 @@ package janitor
 import (
 	"context"
 	"fmt"
-	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -14,29 +14,18 @@ import (
 type Janitor struct {
 	cluster Cluster
 	config  *Config
+	log     *Logger
 	cache   map[string]interface{}
 }
 
-// New creates a Janitor that works through the given Cluster.
+// New creates a Janitor that works through the given Cluster, reporting what it
+// does in the format the Config names.
 func New(config *Config, cluster Cluster) *Janitor {
 	return &Janitor{
 		cluster: cluster,
 		config:  config,
+		log:     NewLogger(config, os.Stderr),
 		cache:   make(map[string]interface{}),
-	}
-}
-
-// debugLog logs a message if debug mode is enabled
-func (j *Janitor) debugLog(format string, args ...interface{}) {
-	if j.config.Debug {
-		log.Printf("DEBUG: "+format, args...)
-	}
-}
-
-// infoLog logs a message at the info level (always visible unless quiet mode is enabled)
-func (j *Janitor) infoLog(format string, args ...interface{}) {
-	if !j.config.Quiet {
-		log.Printf("INFO: "+format, args...)
 	}
 }
 
@@ -45,44 +34,44 @@ func (j *Janitor) infoLog(format string, args ...interface{}) {
 // What the run considers is settled up front by the Selector, so the loop below
 // only lists and acts. Every resource is reached through exactly one Listing.
 func (j *Janitor) CleanUp(ctx context.Context) error {
-	j.debugLog("Starting cleanup run")
+	j.log.Debugf("Starting cleanup run")
 
 	resourceTypes, err := GetResourceTypes(j.cluster.Typed)
 	if err != nil {
 		return fmt.Errorf("failed to get resource types: %v", err)
 	}
-	j.debugLog("Found %d resource types", len(resourceTypes))
+	j.log.Debugf("Found %d resource types", len(resourceTypes))
 
 	namespaces, err := j.namespaceNames(ctx)
 	if err != nil {
 		return err
 	}
-	j.debugLog("Found %d namespaces", len(namespaces))
+	j.log.Debugf("Found %d namespaces", len(namespaces))
 
 	sel := newSelector(j.config)
 	listings := sel.listings(resourceTypes, namespaces)
-	j.debugLog("Considering %d listings", len(listings))
+	j.log.Debugf("Considering %d listings", len(listings))
 
 	counter := make(map[string]int)
 
 	for _, l := range listings {
 		if ctx.Err() != nil {
-			j.debugLog("Context cancelled, stopping the run")
+			j.log.Debugf("Context cancelled, stopping the run")
 			break
 		}
 
 		targets, err := j.listTargets(ctx, l)
 		if err != nil {
-			log.Printf("Error listing %s in namespace %q: %v", l.Type.Plural, l.Namespace, err)
+			j.log.Errorf("Error listing %s in namespace %q: %v", l.Type.Plural, l.Namespace, err)
 			continue
 		}
-		j.debugLog("Found %d %s in namespace %q", len(targets), l.Type.Plural, l.Namespace)
+		j.log.Debugf("Found %d %s in namespace %q", len(targets), l.Type.Plural, l.Namespace)
 
 		j.processTargets(ctx, sel, targets, counter)
 	}
 
 	j.logCleanupSummary(counter)
-	j.debugLog("Cleanup run completed")
+	j.log.Debugf("Cleanup run completed")
 	return nil
 }
 
@@ -125,17 +114,17 @@ func (j *Janitor) listTargets(ctx context.Context, l listing) ([]Target, error) 
 func (j *Janitor) processTargets(ctx context.Context, sel *selector, targets []Target, counter map[string]int) {
 	for _, t := range targets {
 		if ctx.Err() != nil {
-			j.debugLog("Context cancelled, stopping resource processing")
+			j.log.Debugf("Context cancelled, stopping resource processing")
 			return
 		}
 
 		if !sel.admits(t) {
-			j.debugLog("Resource %s is not considered by this run, skipping", t.describe())
+			j.log.Debugf("Resource %s is not considered by this run, skipping", t.describe())
 			continue
 		}
 
 		if err := j.handleResource(ctx, t, counter); err != nil {
-			log.Printf("Error handling %s: %v", t.describe(), err)
+			j.log.Errorf("Error handling %s: %v", t.describe(), err)
 		}
 	}
 }
@@ -153,9 +142,9 @@ func (j *Janitor) handleResource(ctx context.Context, t Target, counter map[stri
 	}
 
 	if verdict.Action == ActionNone {
-		j.debugLog("%s: nothing to do (%s)", t.describe(), verdict.Source)
+		j.log.Debugf("%s: nothing to do (%s)", t.describe(), verdict.Source)
 	} else {
-		j.infoLog("%s: %s, deadline %s (%s)", t.describe(), verdict.Action,
+		j.log.Infof("%s: %s, deadline %s (%s)", t.describe(), verdict.Action,
 			verdict.Deadline.Format(time.RFC3339), verdict.Source)
 	}
 
@@ -176,28 +165,23 @@ func (j *Janitor) handleResource(ctx context.Context, t Target, counter map[stri
 func (j *Janitor) resourceContext(ctx context.Context, t Target) map[string]interface{} {
 	data, err := j.getResourceContext(ctx, t)
 	if err != nil {
-		log.Printf("Warning: failed to get context for %s: %v", t.describe(), err)
+		j.log.Warnf("failed to get context for %s: %v", t.describe(), err)
 		return map[string]interface{}{}
 	}
 	return data
 }
 
+// logCleanupSummary reports what the run did. The Logger decides which of these
+// lines are written, so nothing here checks whether the run is quiet.
 func (j *Janitor) logCleanupSummary(counter map[string]int) {
-	if j.config.Quiet {
-		return
-	}
-
 	var stats []string
 	for k, v := range counter {
 		stats = append(stats, fmt.Sprintf("%s=%d", k, v))
 	}
 
-	log.Printf("Clean up run completed: %s", strings.Join(stats, ", "))
+	j.log.Infof("Clean up run completed: %s", strings.Join(stats, ", "))
 
-	if j.config.Debug {
-		j.debugLog("Detailed counter values:")
-		for k, v := range counter {
-			j.debugLog("  %s: %d", k, v)
-		}
+	for k, v := range counter {
+		j.log.Debugf("  %s: %d", k, v)
 	}
 }

--- a/pkg/janitor/janitor.go
+++ b/pkg/janitor/janitor.go
@@ -3,7 +3,6 @@ package janitor
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -19,12 +18,16 @@ type Janitor struct {
 }
 
 // New creates a Janitor that works through the given Cluster, reporting what it
-// does in the format the Config names.
-func New(config *Config, cluster Cluster) *Janitor {
+// does through the given Logger.
+//
+// The Logger is passed in rather than built here, so that everything one
+// process writes goes through one Logger and a test can read back what a run
+// said.
+func New(config *Config, cluster Cluster, log *Logger) *Janitor {
 	return &Janitor{
 		cluster: cluster,
 		config:  config,
-		log:     NewLogger(config, os.Stderr),
+		log:     log,
 		cache:   make(map[string]interface{}),
 	}
 }

--- a/pkg/janitor/janitor_test.go
+++ b/pkg/janitor/janitor_test.go
@@ -208,7 +208,7 @@ func TestCleanUp(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := NewConfig()
+			cfg := newConfig()
 			if tt.configure != nil {
 				tt.configure(cfg)
 			}
@@ -251,7 +251,7 @@ func TestCleanUp(t *testing.T) {
 // produced "ingresss", which the include list rejected and the API server would
 // not have recognised.
 func TestCleanUpDeletesAnIrregularlyPluralisedResource(t *testing.T) {
-	cfg := NewConfig()
+	cfg := newConfig()
 	cfg.IncludeResources = []string{"ingresses"}
 
 	j := newRunFixture(t, cfg, clusterFixture{
@@ -275,7 +275,7 @@ func TestCleanUpDeletesAnIrregularlyPluralisedResource(t *testing.T) {
 // events and sent two notifications. The Selector yields one Listing per Resource
 // type, so there is no second reach to make.
 func TestCleanUpActsOnANamespaceOnce(t *testing.T) {
-	cfg := NewConfig()
+	cfg := newConfig()
 	cfg.IncludeClusterResources = true
 	cfg.DeleteNotification = int(time.Hour.Seconds())
 
@@ -303,7 +303,7 @@ func TestCleanUpActsOnANamespaceOnce(t *testing.T) {
 // Namespaces are the one cluster-scoped type a run handles without
 // --include-cluster-resources: see the flag's entry in the README.
 func TestCleanUpDeletesANamespaceWithoutClusterResources(t *testing.T) {
-	cfg := NewConfig()
+	cfg := newConfig()
 
 	j := newRunFixture(t, cfg, clusterFixture{
 		types:      []ResourceType{namespaceResourceType},
@@ -325,7 +325,7 @@ func TestCleanUpDeletesANamespaceWithoutClusterResources(t *testing.T) {
 // A namespace is excluded by name, the same lists that exclude the resources
 // inside it.
 func TestCleanUpLeavesAnExcludedNamespaceAlone(t *testing.T) {
-	cfg := NewConfig()
+	cfg := newConfig()
 
 	j := newRunFixture(t, cfg, clusterFixture{
 		types:      []ResourceType{namespaceResourceType},
@@ -356,7 +356,7 @@ func TestCleanUpLeavesAnExcludedNamespaceAlone(t *testing.T) {
 // again through the dynamic client, because that is the path every resource it
 // judges arrives by.
 func TestCleanUpReadsTheNamespaceListOnceToPlan(t *testing.T) {
-	cfg := NewConfig()
+	cfg := newConfig()
 
 	j := newRunFixture(t, cfg, clusterFixture{
 		types:      []ResourceType{podResourceType, deploymentResourceType, ingressResourceType},

--- a/pkg/janitor/janitor_test.go
+++ b/pkg/janitor/janitor_test.go
@@ -2,6 +2,7 @@ package janitor
 
 import (
 	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -21,10 +22,14 @@ import (
 // discovery reports, the namespaces the cluster holds, and the resources in them.
 // A namespace a run may judge has to be named in namespaces and supplied as an
 // object, the way a real cluster serves it to both clients.
+//
+// out is where the run's log lines go. A case that does not care leaves it nil
+// and the lines are dropped.
 type clusterFixture struct {
 	types      []ResourceType
 	namespaces []string
 	objects    []*unstructured.Unstructured
+	out        io.Writer
 }
 
 // newRunFixture is a Janitor handed fake connections holding the fixture. Because
@@ -60,7 +65,13 @@ func newRunFixture(t *testing.T, cfg *Config, f clusterFixture) *Janitor {
 		listed = append(listed, o)
 	}
 
-	return New(cfg, Cluster{Typed: typed, Dynamic: dynamicClientFor(f.types, listed...)})
+	out := f.out
+	if out == nil {
+		out = io.Discard
+	}
+
+	return New(cfg, Cluster{Typed: typed, Dynamic: dynamicClientFor(f.types, listed...)},
+		NewLogger(cfg, out))
 }
 
 // events reports the Kubernetes events a run recorded, in order. Counting them is

--- a/pkg/janitor/janitor_test.go
+++ b/pkg/janitor/janitor_test.go
@@ -257,6 +257,32 @@ func TestCleanUp(t *testing.T) {
 	}
 }
 
+// A run reports what it did through the Logger it was handed, so a process that
+// builds one Logger sees the whole of its own output. Nothing in the janitor
+// reaches for standard error on its own.
+func TestCleanUpReportsThroughTheLoggerItWasGiven(t *testing.T) {
+	var said strings.Builder
+
+	cfg := newConfig()
+	cfg.LogFormat = "%(levelname)s %(message)s"
+
+	j := newRunFixture(t, cfg, clusterFixture{
+		types:   []ResourceType{podResourceType},
+		objects: []*unstructured.Unstructured{expiredObject(podResourceType, "staging", "web")},
+		out:     &said,
+	})
+
+	if err := j.CleanUp(context.Background()); err != nil {
+		t.Fatalf("CleanUp() error = %v", err)
+	}
+
+	for _, want := range []string{"INFO Pod staging/web", "INFO Clean up run completed", "pods-deleted=1"} {
+		if !strings.Contains(said.String(), want) {
+			t.Errorf("the run never said %q. It said:\n%s", want, said.String())
+		}
+	}
+}
+
 // A resource whose plural is not its kind plus "s" has to survive discovery,
 // filtering, rule matching and deletion with that plural intact. Guessing it
 // produced "ingresss", which the include list rejected and the API server would

--- a/pkg/janitor/logging.go
+++ b/pkg/janitor/logging.go
@@ -17,15 +17,34 @@ const loggerName = "kube-janitor"
 // always printed, so a default format produces the line it always did.
 const asctimeLayout = "2006-01-02 15:04:05"
 
-// The levels a line can carry. They are the names Python's logging module uses,
-// because the log format is written in its placeholder syntax and %(levelname)s
-// is expected to render the same words.
+// logLevel says what kind of thing a line reports. The levels are ordered from
+// the one only a diagnosed run wants to the one no run can suppress, so a run
+// keeps a single lowest level rather than one switch per level.
+type logLevel int
+
 const (
-	levelDebug   = "DEBUG"
-	levelInfo    = "INFO"
-	levelWarning = "WARNING"
-	levelError   = "ERROR"
+	levelDebug logLevel = iota
+	levelInfo
+	levelWarning
+	levelError
 )
+
+// String names the level the way Python's logging module does, because the log
+// format is written in its placeholder syntax and %(levelname)s is expected to
+// render the same words.
+func (l logLevel) String() string {
+	switch l {
+	case levelDebug:
+		return "DEBUG"
+	case levelInfo:
+		return "INFO"
+	case levelWarning:
+		return "WARNING"
+	case levelError:
+		return "ERROR"
+	}
+	return "UNKNOWN"
+}
 
 // logField is one value a log format interpolates.
 type logField int
@@ -118,25 +137,39 @@ func knownLogFields() []string {
 	return names
 }
 
+// logRecord is the one event a line reports, before the format has had its say.
+type logRecord struct {
+	level   logLevel
+	message string
+	now     time.Time
+}
+
+// value renders the one field of the record a placeholder names.
+func (r logRecord) value(field logField) string {
+	switch field {
+	case fieldAsctime:
+		return r.now.Format(asctimeLayout)
+	case fieldCreated:
+		return strconv.FormatFloat(float64(r.now.UnixNano())/1e9, 'f', 3, 64)
+	case fieldLevelName:
+		return r.level.String()
+	case fieldMessage:
+		return r.message
+	case fieldName:
+		return loggerName
+	}
+	return ""
+}
+
 // render builds one line from the compiled template.
-func (f logFormat) render(level, message string, now time.Time) string {
+func (f logFormat) render(level logLevel, message string, now time.Time) string {
+	rec := logRecord{level: level, message: message, now: now}
+
 	var line strings.Builder
 
 	for i, field := range f.fields {
 		line.WriteString(f.literals[i])
-
-		switch field {
-		case fieldAsctime:
-			line.WriteString(now.Format(asctimeLayout))
-		case fieldCreated:
-			line.WriteString(strconv.FormatFloat(float64(now.UnixNano())/1e9, 'f', 3, 64))
-		case fieldLevelName:
-			line.WriteString(level)
-		case fieldMessage:
-			line.WriteString(message)
-		case fieldName:
-			line.WriteString(loggerName)
-		}
+		line.WriteString(rec.value(field))
 	}
 
 	line.WriteString(f.literals[len(f.literals)-1])
@@ -145,16 +178,17 @@ func (f logFormat) render(level, message string, now time.Time) string {
 
 // Logger writes one line per event, in the format the Configuration names.
 //
-// It also decides which lines are written at all: debug lines only when debug
-// is on, and info lines unless the run is quiet. Warnings and errors are always
-// written, so a quiet run still reports what went wrong.
+// It also decides which lines are written at all, from the one lowest level the
+// Configuration works out to. Nothing that emits a line checks whether the line
+// is wanted.
 type Logger struct {
 	format logFormat
-	debug  bool
-	quiet  bool
+	min    logLevel
 
 	// mu keeps one line from interleaving with another, which is the guarantee
-	// the standard log package gave before.
+	// the standard log package gave before. It only holds for lines written
+	// through this Logger, so a process builds one and passes it around rather
+	// than building a second onto the same writer.
 	mu  sync.Mutex
 	out io.Writer
 }
@@ -170,21 +204,31 @@ func NewLogger(cfg *Config, out io.Writer) *Logger {
 		format, _ = parseLogFormat(defaultLogFormat)
 	}
 
-	return &Logger{format: format, debug: cfg.Debug, quiet: cfg.Quiet, out: out}
+	return &Logger{format: format, min: lowestLevel(cfg), out: out}
+}
+
+// lowestLevel works out the least a run reports. Asking for a diagnosis beats
+// asking for quiet: a run given both is being diagnosed, and a diagnosis that
+// left out the ordinary course of the run would be a poor one.
+func lowestLevel(cfg *Config) logLevel {
+	switch {
+	case cfg.Debug:
+		return levelDebug
+	case cfg.Quiet:
+		return levelWarning
+	default:
+		return levelInfo
+	}
 }
 
 // Debugf writes a line a run only wants when it is being diagnosed.
 func (l *Logger) Debugf(format string, args ...interface{}) {
-	if l.debug {
-		l.write(levelDebug, format, args)
-	}
+	l.write(levelDebug, format, args)
 }
 
 // Infof writes a line describing the ordinary course of a run.
 func (l *Logger) Infof(format string, args ...interface{}) {
-	if !l.quiet {
-		l.write(levelInfo, format, args)
-	}
+	l.write(levelInfo, format, args)
 }
 
 // Warnf writes a line about something a run worked around.
@@ -200,11 +244,16 @@ func (l *Logger) Errorf(format string, args ...interface{}) {
 // write renders one line and puts it out whole. The message is formatted only
 // once the level has been admitted, so a suppressed line costs nothing beyond
 // the call.
-func (l *Logger) write(level, format string, args []interface{}) {
+func (l *Logger) write(level logLevel, format string, args []interface{}) {
+	if level < l.min {
+		return
+	}
+
 	line := l.format.render(level, fmt.Sprintf(format, args...), time.Now())
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	fmt.Fprintln(l.out, line)
+	// Nowhere left to report a writer that will not take a log line.
+	_, _ = fmt.Fprintln(l.out, line)
 }

--- a/pkg/janitor/logging.go
+++ b/pkg/janitor/logging.go
@@ -10,9 +10,6 @@ import (
 	"time"
 )
 
-// loggerName is what %(name)s renders: the program a log line came from.
-const loggerName = "kube-janitor"
-
 // asctimeLayout is what %(asctime)s renders. It is the layout the janitor has
 // always printed, so a default format produces the line it always did.
 const asctimeLayout = "2006-01-02 15:04:05"
@@ -72,15 +69,19 @@ var logFields = map[string]logField{
 // placeholders, and the field that fills each gap. Compiling once means a run
 // does no parsing per line.
 type logFormat struct {
-	// literals holds one more entry than fields: the text before each field,
-	// then the text after the last one.
-	literals []string
-	fields   []logField
+	// literals holds one more entry than placeholders: the text before each
+	// one, then the text after the last one.
+	literals     []string
+	placeholders []placeholder
+}
 
-	// quoted says, per field, whether the format puts it between two double
-	// quotes. Such a field is a string in whatever the format is building, so
-	// its value is escaped rather than written through.
-	quoted []bool
+// placeholder is one gap a format leaves: the field that fills it, and whether
+// the format put that field between two double quotes. A quoted field is a
+// string in whatever the format is building, so its value is escaped rather
+// than written through.
+type placeholder struct {
+	field  logField
+	quoted bool
 }
 
 // parseLogFormat compiles a log format written in Python's logging syntax,
@@ -123,22 +124,26 @@ func parseLogFormat(format string) (logFormat, error) {
 
 		f.literals = append(f.literals, literal.String())
 		literal.Reset()
-		f.fields = append(f.fields, field)
+		f.placeholders = append(f.placeholders, placeholder{field: field})
 		i += end + 2
 	}
 
 	f.literals = append(f.literals, literal.String())
-	f.markQuotedFields()
+	f.markQuotedPlaceholders()
 	return f, nil
 }
 
-// markQuotedFields works out which fields the format wrapped in quotes. It can
-// only be decided once the whole format is compiled, because a field is quoted
-// by the literal after it as much as by the literal before it.
-func (f *logFormat) markQuotedFields() {
-	f.quoted = make([]bool, len(f.fields))
-	for i := range f.fields {
-		f.quoted[i] = strings.HasSuffix(f.literals[i], `"`) &&
+// markQuotedPlaceholders works out which fields the format wrapped in quotes.
+// It can only be decided once the whole format is compiled, because a field is
+// quoted by the literal after it as much as by the literal before it.
+//
+// Keying on the quotes rather than on the shape as a whole is what lets one
+// rule serve JSON and the logfmt-style formats alike. It is deliberately the
+// only structure this reads out of a format: a second such inference would
+// mean the format should name its shape instead of implying it.
+func (f *logFormat) markQuotedPlaceholders() {
+	for i := range f.placeholders {
+		f.placeholders[i].quoted = strings.HasSuffix(f.literals[i], `"`) &&
 			strings.HasPrefix(f.literals[i+1], `"`)
 	}
 }
@@ -173,7 +178,7 @@ func (r logRecord) value(field logField) string {
 	case fieldMessage:
 		return r.message
 	case fieldName:
-		return loggerName
+		return programName
 	}
 	return ""
 }
@@ -184,19 +189,24 @@ func (f logFormat) render(level logLevel, message string, now time.Time) string 
 
 	var line strings.Builder
 
-	for i, field := range f.fields {
+	for i, p := range f.placeholders {
 		line.WriteString(f.literals[i])
 
-		if f.quoted[i] {
-			writeQuotedValue(&line, rec.value(field))
+		value := rec.value(p.field)
+		if p.quoted {
+			writeQuotedValue(&line, value)
 		} else {
-			line.WriteString(rec.value(field))
+			line.WriteString(value)
 		}
 	}
 
 	line.WriteString(f.literals[len(f.literals)-1])
 	return line.String()
 }
+
+// hexDigits spells the \u escape writeQuotedValue emits for a control
+// character.
+const hexDigits = "0123456789abcdef"
 
 // writeQuotedValue writes value as the body of a quoted string, escaping the
 // characters that would otherwise end the string early or break the line in
@@ -217,7 +227,12 @@ func writeQuotedValue(line *strings.Builder, value string) {
 		case r == '\t':
 			line.WriteString(`\t`)
 		case r < 0x20:
-			fmt.Fprintf(line, `\u%04x`, r)
+			// Written out rather than handed to fmt: taking an io.Writer here
+			// would move the whole line's Builder to the heap, on every line.
+			// r < 0x20 means the top two nibbles are zero.
+			line.WriteString(`\u00`)
+			line.WriteByte(hexDigits[r>>4])
+			line.WriteByte(hexDigits[r&0xf])
 		default:
 			line.WriteRune(r)
 		}
@@ -252,21 +267,7 @@ func NewLogger(cfg *Config, out io.Writer) *Logger {
 		format, _ = parseLogFormat(defaultLogFormat)
 	}
 
-	return &Logger{format: format, min: lowestLevel(cfg), out: out}
-}
-
-// lowestLevel works out the least a run reports. Asking for a diagnosis beats
-// asking for quiet: a run given both is being diagnosed, and a diagnosis that
-// left out the ordinary course of the run would be a poor one.
-func lowestLevel(cfg *Config) logLevel {
-	switch {
-	case cfg.Debug:
-		return levelDebug
-	case cfg.Quiet:
-		return levelWarning
-	default:
-		return levelInfo
-	}
+	return &Logger{format: format, min: cfg.lowestLogLevel(), out: out}
 }
 
 // Debugf writes a line a run only wants when it is being diagnosed.

--- a/pkg/janitor/logging.go
+++ b/pkg/janitor/logging.go
@@ -76,6 +76,11 @@ type logFormat struct {
 	// then the text after the last one.
 	literals []string
 	fields   []logField
+
+	// quoted says, per field, whether the format puts it between two double
+	// quotes. Such a field is a string in whatever the format is building, so
+	// its value is escaped rather than written through.
+	quoted []bool
 }
 
 // parseLogFormat compiles a log format written in Python's logging syntax,
@@ -123,7 +128,19 @@ func parseLogFormat(format string) (logFormat, error) {
 	}
 
 	f.literals = append(f.literals, literal.String())
+	f.markQuotedFields()
 	return f, nil
+}
+
+// markQuotedFields works out which fields the format wrapped in quotes. It can
+// only be decided once the whole format is compiled, because a field is quoted
+// by the literal after it as much as by the literal before it.
+func (f *logFormat) markQuotedFields() {
+	f.quoted = make([]bool, len(f.fields))
+	for i := range f.fields {
+		f.quoted[i] = strings.HasSuffix(f.literals[i], `"`) &&
+			strings.HasPrefix(f.literals[i+1], `"`)
+	}
 }
 
 // knownLogFields names the placeholders a format may use, in a stable order so
@@ -169,11 +186,42 @@ func (f logFormat) render(level logLevel, message string, now time.Time) string 
 
 	for i, field := range f.fields {
 		line.WriteString(f.literals[i])
-		line.WriteString(rec.value(field))
+
+		if f.quoted[i] {
+			writeQuotedValue(&line, rec.value(field))
+		} else {
+			line.WriteString(rec.value(field))
+		}
 	}
 
 	line.WriteString(f.literals[len(f.literals)-1])
 	return line.String()
+}
+
+// writeQuotedValue writes value as the body of a quoted string, escaping the
+// characters that would otherwise end the string early or break the line in
+// two. A format that wraps a field in quotes is building JSON or something
+// shaped like it, and a message carrying a quote of its own — which one
+// naming a namespace does — would leave it unparseable.
+func writeQuotedValue(line *strings.Builder, value string) {
+	for _, r := range value {
+		switch {
+		case r == '"':
+			line.WriteString(`\"`)
+		case r == '\\':
+			line.WriteString(`\\`)
+		case r == '\n':
+			line.WriteString(`\n`)
+		case r == '\r':
+			line.WriteString(`\r`)
+		case r == '\t':
+			line.WriteString(`\t`)
+		case r < 0x20:
+			fmt.Fprintf(line, `\u%04x`, r)
+		default:
+			line.WriteRune(r)
+		}
+	}
 }
 
 // Logger writes one line per event, in the format the Configuration names.

--- a/pkg/janitor/logging.go
+++ b/pkg/janitor/logging.go
@@ -1,0 +1,210 @@
+package janitor
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// loggerName is what %(name)s renders: the program a log line came from.
+const loggerName = "kube-janitor"
+
+// asctimeLayout is what %(asctime)s renders. It is the layout the janitor has
+// always printed, so a default format produces the line it always did.
+const asctimeLayout = "2006-01-02 15:04:05"
+
+// The levels a line can carry. They are the names Python's logging module uses,
+// because the log format is written in its placeholder syntax and %(levelname)s
+// is expected to render the same words.
+const (
+	levelDebug   = "DEBUG"
+	levelInfo    = "INFO"
+	levelWarning = "WARNING"
+	levelError   = "ERROR"
+)
+
+// logField is one value a log format interpolates.
+type logField int
+
+const (
+	fieldAsctime logField = iota
+	fieldCreated
+	fieldLevelName
+	fieldMessage
+	fieldName
+)
+
+// logFields names every placeholder a format may use. A name that is not here
+// is refused when the configuration loads rather than rendered as empty, so a
+// format that would silently drop a field never reaches a run.
+var logFields = map[string]logField{
+	"asctime":   fieldAsctime,
+	"created":   fieldCreated,
+	"levelname": fieldLevelName,
+	"message":   fieldMessage,
+	"name":      fieldName,
+}
+
+// logFormat is a compiled log line template: the literal text around the
+// placeholders, and the field that fills each gap. Compiling once means a run
+// does no parsing per line.
+type logFormat struct {
+	// literals holds one more entry than fields: the text before each field,
+	// then the text after the last one.
+	literals []string
+	fields   []logField
+}
+
+// parseLogFormat compiles a log format written in Python's logging syntax,
+// where %(name)s names a field. It reports what is wrong with a format it
+// cannot compile, and which fields it would have accepted.
+func parseLogFormat(format string) (logFormat, error) {
+	var f logFormat
+	var literal strings.Builder
+
+	for i := 0; i < len(format); {
+		// %% is a literal percent, as it is in the Python format this syntax
+		// comes from, so a format ported from there reads the same.
+		if strings.HasPrefix(format[i:], "%%") {
+			literal.WriteByte('%')
+			i += 2
+			continue
+		}
+
+		if !strings.HasPrefix(format[i:], "%(") {
+			literal.WriteByte(format[i])
+			i++
+			continue
+		}
+
+		end := strings.Index(format[i:], ")")
+		if end < 0 {
+			return logFormat{}, fmt.Errorf("log format has an unclosed placeholder: %q", format[i:])
+		}
+
+		name := format[i+2 : i+end]
+		if !strings.HasPrefix(format[i+end+1:], "s") {
+			return logFormat{}, fmt.Errorf("log format placeholder %%(%s) must be written %%(%s)s", name, name)
+		}
+
+		field, known := logFields[name]
+		if !known {
+			return logFormat{}, fmt.Errorf("log format has unknown placeholder %%(%s)s, want one of %s",
+				name, strings.Join(knownLogFields(), ", "))
+		}
+
+		f.literals = append(f.literals, literal.String())
+		literal.Reset()
+		f.fields = append(f.fields, field)
+		i += end + 2
+	}
+
+	f.literals = append(f.literals, literal.String())
+	return f, nil
+}
+
+// knownLogFields names the placeholders a format may use, in a stable order so
+// that an error message reads the same every time.
+func knownLogFields() []string {
+	names := make([]string, 0, len(logFields))
+	for name := range logFields {
+		names = append(names, "%("+name+")s")
+	}
+	slices.Sort(names)
+	return names
+}
+
+// render builds one line from the compiled template.
+func (f logFormat) render(level, message string, now time.Time) string {
+	var line strings.Builder
+
+	for i, field := range f.fields {
+		line.WriteString(f.literals[i])
+
+		switch field {
+		case fieldAsctime:
+			line.WriteString(now.Format(asctimeLayout))
+		case fieldCreated:
+			line.WriteString(strconv.FormatFloat(float64(now.UnixNano())/1e9, 'f', 3, 64))
+		case fieldLevelName:
+			line.WriteString(level)
+		case fieldMessage:
+			line.WriteString(message)
+		case fieldName:
+			line.WriteString(loggerName)
+		}
+	}
+
+	line.WriteString(f.literals[len(f.literals)-1])
+	return line.String()
+}
+
+// Logger writes one line per event, in the format the Configuration names.
+//
+// It also decides which lines are written at all: debug lines only when debug
+// is on, and info lines unless the run is quiet. Warnings and errors are always
+// written, so a quiet run still reports what went wrong.
+type Logger struct {
+	format logFormat
+	debug  bool
+	quiet  bool
+
+	// mu keeps one line from interleaving with another, which is the guarantee
+	// the standard log package gave before.
+	mu  sync.Mutex
+	out io.Writer
+}
+
+// NewLogger builds the Logger a Configuration asks for, writing to out.
+//
+// A Config that came from LoadConfig carries a format that is already known to
+// compile. A Config built by hand may carry none, or one that does not compile,
+// and gets the default format rather than an unusable Logger.
+func NewLogger(cfg *Config, out io.Writer) *Logger {
+	format, err := parseLogFormat(cfg.LogFormat)
+	if cfg.LogFormat == "" || err != nil {
+		format, _ = parseLogFormat(defaultLogFormat)
+	}
+
+	return &Logger{format: format, debug: cfg.Debug, quiet: cfg.Quiet, out: out}
+}
+
+// Debugf writes a line a run only wants when it is being diagnosed.
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	if l.debug {
+		l.write(levelDebug, format, args)
+	}
+}
+
+// Infof writes a line describing the ordinary course of a run.
+func (l *Logger) Infof(format string, args ...interface{}) {
+	if !l.quiet {
+		l.write(levelInfo, format, args)
+	}
+}
+
+// Warnf writes a line about something a run worked around.
+func (l *Logger) Warnf(format string, args ...interface{}) {
+	l.write(levelWarning, format, args)
+}
+
+// Errorf writes a line about something a run could not do.
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.write(levelError, format, args)
+}
+
+// write renders one line and puts it out whole. The message is formatted only
+// once the level has been admitted, so a suppressed line costs nothing beyond
+// the call.
+func (l *Logger) write(level, format string, args []interface{}) {
+	line := l.format.render(level, fmt.Sprintf(format, args...), time.Now())
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	fmt.Fprintln(l.out, line)
+}

--- a/pkg/janitor/logging.go
+++ b/pkg/janitor/logging.go
@@ -76,9 +76,8 @@ type logFormat struct {
 }
 
 // placeholder is one gap a format leaves: the field that fills it, and whether
-// the format put that field between two double quotes. A quoted field is a
-// string in whatever the format is building, so its value is escaped rather
-// than written through.
+// it falls inside a quoted string. A quoted field is a string in whatever the
+// format is building, so its value is escaped rather than written through.
 type placeholder struct {
 	field  logField
 	quoted bool
@@ -90,6 +89,7 @@ type placeholder struct {
 func parseLogFormat(format string) (logFormat, error) {
 	var f logFormat
 	var literal strings.Builder
+	var quotes quoteScanner
 
 	for i := 0; i < len(format); {
 		// %% is a literal percent, as it is in the Python format this syntax
@@ -102,6 +102,7 @@ func parseLogFormat(format string) (logFormat, error) {
 
 		if !strings.HasPrefix(format[i:], "%(") {
 			literal.WriteByte(format[i])
+			quotes.read(format[i])
 			i++
 			continue
 		}
@@ -124,27 +125,38 @@ func parseLogFormat(format string) (logFormat, error) {
 
 		f.literals = append(f.literals, literal.String())
 		literal.Reset()
-		f.placeholders = append(f.placeholders, placeholder{field: field})
+		f.placeholders = append(f.placeholders, placeholder{field: field, quoted: quotes.inString})
 		i += end + 2
 	}
 
 	f.literals = append(f.literals, literal.String())
-	f.markQuotedPlaceholders()
 	return f, nil
 }
 
-// markQuotedPlaceholders works out which fields the format wrapped in quotes.
-// It can only be decided once the whole format is compiled, because a field is
-// quoted by the literal after it as much as by the literal before it.
+// quoteScanner tracks whether the format's own text has an open double quote at
+// the point it has read up to. A placeholder reached with one open sits inside
+// a string, whatever the format is building — a JSON value, a logfmt value, or
+// a quoted name in a plain line — and its value has to be escaped to stay
+// inside it.
 //
 // Keying on the quotes rather than on the shape as a whole is what lets one
-// rule serve JSON and the logfmt-style formats alike. It is deliberately the
-// only structure this reads out of a format: a second such inference would
-// mean the format should name its shape instead of implying it.
-func (f *logFormat) markQuotedPlaceholders() {
-	for i := range f.placeholders {
-		f.placeholders[i].quoted = strings.HasSuffix(f.literals[i], `"`) &&
-			strings.HasPrefix(f.literals[i+1], `"`)
+// rule serve JSON and logfmt alike. It is deliberately the only structure this
+// reads out of a format: a second such inference would mean the format should
+// name its shape rather than imply it.
+type quoteScanner struct {
+	inString bool
+	escaped  bool
+}
+
+// read takes the next byte of the format's literal text.
+func (q *quoteScanner) read(c byte) {
+	switch {
+	case q.escaped:
+		q.escaped = false
+	case c == '\\':
+		q.escaped = true
+	case c == '"':
+		q.inString = !q.inString
 	}
 }
 

--- a/pkg/janitor/logging_test.go
+++ b/pkg/janitor/logging_test.go
@@ -11,6 +11,10 @@ import (
 // case can state the whole line it expects.
 var at = time.Date(2026, 8, 24, 13, 56, 40, 500_000_000, time.UTC)
 
+// documentedJSONFormat is the JSON log format the README offers, written once
+// so that the cases below cannot pin different versions of it.
+const documentedJSONFormat = `{"level":"%(levelname)s","ts":"%(created)s","logger":"%(name)s","msg":"%(message)s"}`
+
 func TestLogFormatRenders(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -91,9 +95,7 @@ func TestLogFormatRenders(t *testing.T) {
 // The README offers a JSON log format, so one has to come out as parseable JSON
 // rather than as a line that merely looks like it.
 func TestLogFormatRendersTheDocumentedJSONExample(t *testing.T) {
-	const documented = `{"level":"%(levelname)s","ts":"%(created)s","logger":"%(name)s","msg":"%(message)s"}`
-
-	format, err := parseLogFormat(documented)
+	format, err := parseLogFormat(documentedJSONFormat)
 	if err != nil {
 		t.Fatalf("parseLogFormat returned %v for the format the README documents", err)
 	}
@@ -122,9 +124,7 @@ func TestLogFormatRendersTheDocumentedJSONExample(t *testing.T) {
 // the name, so the JSON the README offers has to survive a message that carries
 // quotes of its own. This is the message a failed listing actually produces.
 func TestLogFormatEscapesAQuotedFieldsValue(t *testing.T) {
-	const documented = `{"level":"%(levelname)s","ts":"%(created)s","logger":"%(name)s","msg":"%(message)s"}`
-
-	format, err := parseLogFormat(documented)
+	format, err := parseLogFormat(documentedJSONFormat)
 	if err != nil {
 		t.Fatalf("parseLogFormat returned %v", err)
 	}

--- a/pkg/janitor/logging_test.go
+++ b/pkg/janitor/logging_test.go
@@ -15,7 +15,7 @@ func TestLogFormatRenders(t *testing.T) {
 	tests := []struct {
 		name    string
 		format  string
-		level   string
+		level   logLevel
 		message string
 		want    string
 	}{
@@ -197,9 +197,11 @@ func TestLoggerWritesTheLevelsTheConfigAdmits(t *testing.T) {
 			want: []string{"WARNING", "ERROR"},
 		},
 		{
+			// Asking for both is asking for a diagnosis, and a diagnosis that
+			// left out the ordinary course of the run would be a poor one.
 			name: "a quiet run being diagnosed",
 			cfg:  &Config{Debug: true, Quiet: true},
-			want: []string{"DEBUG", "WARNING", "ERROR"},
+			want: []string{"DEBUG", "INFO", "WARNING", "ERROR"},
 		},
 	}
 

--- a/pkg/janitor/logging_test.go
+++ b/pkg/janitor/logging_test.go
@@ -1,0 +1,270 @@
+package janitor
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// at is the moment every rendered line in these tests is stamped with, so a
+// case can state the whole line it expects.
+var at = time.Date(2026, 8, 24, 13, 56, 40, 500_000_000, time.UTC)
+
+func TestLogFormatRenders(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		level   string
+		message string
+		want    string
+	}{
+		{
+			name:    "the default format",
+			format:  defaultLogFormat,
+			level:   levelInfo,
+			message: "Pod default/web: delete, deadline ... (janitor/ttl)",
+			want:    "2026-08-24 13:56:40 INFO: Pod default/web: delete, deadline ... (janitor/ttl)",
+		},
+		{
+			name:    "a format naming every field",
+			format:  "%(asctime)s|%(created)s|%(levelname)s|%(name)s|%(message)s",
+			level:   levelError,
+			message: "boom",
+			want:    "2026-08-24 13:56:40|1787579800.500|ERROR|kube-janitor|boom",
+		},
+		{
+			name:    "literal text with no placeholder at all",
+			format:  "nothing to interpolate",
+			level:   levelInfo,
+			message: "ignored",
+			want:    "nothing to interpolate",
+		},
+		{
+			name:    "a placeholder repeated",
+			format:  "%(levelname)s %(levelname)s",
+			level:   levelWarning,
+			message: "ignored",
+			want:    "WARNING WARNING",
+		},
+		{
+			// %% is how the Python format this syntax comes from writes a
+			// literal percent.
+			name:    "an escaped percent sign",
+			format:  "100%% sure: %(message)s",
+			level:   levelInfo,
+			message: "yes",
+			want:    "100% sure: yes",
+		},
+		{
+			// A percent that opens nothing is literal text: the format is not a
+			// Go format string, so a stray one is not an error either.
+			name:    "a stray percent sign",
+			format:  "50% off: %(message)s",
+			level:   levelInfo,
+			message: "yes",
+			want:    "50% off: yes",
+		},
+		{
+			name:    "an empty format",
+			format:  "",
+			level:   levelInfo,
+			message: "ignored",
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, err := parseLogFormat(tt.format)
+			if err != nil {
+				t.Fatalf("parseLogFormat(%q) returned %v", tt.format, err)
+			}
+
+			if got := format.render(tt.level, tt.message, at); got != tt.want {
+				t.Errorf("render() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The README offers a JSON log format, so one has to come out as parseable JSON
+// rather than as a line that merely looks like it.
+func TestLogFormatRendersTheDocumentedJSONExample(t *testing.T) {
+	const documented = `{"level":"%(levelname)s","ts":"%(created)s","logger":"%(name)s","msg":"%(message)s"}`
+
+	format, err := parseLogFormat(documented)
+	if err != nil {
+		t.Fatalf("parseLogFormat returned %v for the format the README documents", err)
+	}
+
+	line := format.render(levelInfo, "cleaning up", at)
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("the rendered line is not JSON: %v\nline: %s", err, line)
+	}
+
+	want := map[string]string{
+		"level":  "INFO",
+		"ts":     "1787579800.500",
+		"logger": "kube-janitor",
+		"msg":    "cleaning up",
+	}
+	for key, value := range want {
+		if got[key] != value {
+			t.Errorf("%s = %q, want %q", key, got[key], value)
+		}
+	}
+}
+
+// A format that cannot be rendered is refused where it is written down, not
+// silently turned into blank lines at run time.
+func TestParseLogFormatRefusesAFormatItCannotRender(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{
+			name:   "a placeholder the janitor does not know",
+			format: "%(filename)s: %(message)s",
+			want:   "unknown placeholder %(filename)s",
+		},
+		{
+			name:   "a placeholder that is never closed",
+			format: "%(message: hello",
+			want:   "unclosed placeholder",
+		},
+		{
+			name:   "a placeholder missing its conversion",
+			format: "%(message) hello",
+			want:   "must be written %(message)s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseLogFormat(tt.format)
+
+			if err == nil {
+				t.Fatalf("parseLogFormat(%q) returned no error", tt.format)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("parseLogFormat(%q) = %v, want it to mention %q", tt.format, err, tt.want)
+			}
+		})
+	}
+}
+
+// An unknown placeholder is a typo more often than not, so the error says what
+// could have been written instead.
+func TestParseLogFormatNamesThePlaceholdersItAccepts(t *testing.T) {
+	_, err := parseLogFormat("%(levelnames)s")
+	if err == nil {
+		t.Fatal("parseLogFormat accepted an unknown placeholder")
+	}
+
+	for _, want := range []string{"%(asctime)s", "%(created)s", "%(levelname)s", "%(message)s", "%(name)s"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("the error does not offer %s: %v", want, err)
+		}
+	}
+}
+
+// The level decides whether a line is written at all, which is what --debug and
+// --quiet control.
+func TestLoggerWritesTheLevelsTheConfigAdmits(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+		want []string
+	}{
+		{
+			name: "an ordinary run",
+			cfg:  &Config{},
+			want: []string{"INFO", "WARNING", "ERROR"},
+		},
+		{
+			name: "a run being diagnosed",
+			cfg:  &Config{Debug: true},
+			want: []string{"DEBUG", "INFO", "WARNING", "ERROR"},
+		},
+		{
+			// A quiet run still has to report what went wrong.
+			name: "a quiet run",
+			cfg:  &Config{Quiet: true},
+			want: []string{"WARNING", "ERROR"},
+		},
+		{
+			name: "a quiet run being diagnosed",
+			cfg:  &Config{Debug: true, Quiet: true},
+			want: []string{"DEBUG", "WARNING", "ERROR"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			// The line is just the level, so what was written reads as the list
+			// of levels that got through.
+			tt.cfg.LogFormat = "%(levelname)s"
+			logger := NewLogger(tt.cfg, &out)
+
+			logger.Debugf("a debug line")
+			logger.Infof("an info line")
+			logger.Warnf("a warning line")
+			logger.Errorf("an error line")
+
+			want := strings.Join(tt.want, "\n") + "\n"
+			if got := out.String(); got != want {
+				t.Errorf("wrote levels %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestLoggerFormatsItsArguments(t *testing.T) {
+	var out strings.Builder
+	logger := NewLogger(&Config{LogFormat: "%(message)s"}, &out)
+
+	logger.Infof("deleted %d %s", 3, "pods")
+
+	if got := out.String(); got != "deleted 3 pods\n" {
+		t.Errorf("wrote %q, want %q", got, "deleted 3 pods\n")
+	}
+}
+
+// A Config built by hand carries no format, and must still produce readable
+// lines rather than empty ones.
+func TestNewLoggerFallsBackToTheDefaultFormat(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  *Config
+	}{
+		{name: "no format at all", cfg: &Config{}},
+		{name: "a format that does not compile", cfg: &Config{LogFormat: "%(nonesuch)s"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var out strings.Builder
+			NewLogger(tt.cfg, &out).Infof("hello")
+
+			if got := out.String(); !strings.HasSuffix(got, "INFO: hello\n") {
+				t.Errorf("wrote %q, want a line in the default format", got)
+			}
+		})
+	}
+}
+
+// The format is part of the configuration, so a format that cannot be rendered
+// stops the process at the same point a bad interval does.
+func TestLoadConfigRefusesAnUnusableLogFormat(t *testing.T) {
+	_, err := LoadConfig([]string{"-log-format", "%(nonesuch)s"}, noEnv)
+
+	if err == nil {
+		t.Fatal("LoadConfig accepted a log format it cannot render")
+	}
+	if !strings.Contains(err.Error(), "unknown placeholder %(nonesuch)s") {
+		t.Errorf("LoadConfig = %v, want it to name the placeholder it does not know", err)
+	}
+}

--- a/pkg/janitor/logging_test.go
+++ b/pkg/janitor/logging_test.go
@@ -118,6 +118,76 @@ func TestLogFormatRendersTheDocumentedJSONExample(t *testing.T) {
 	}
 }
 
+// A run says which namespace it was listing, and it says it with quotes around
+// the name, so the JSON the README offers has to survive a message that carries
+// quotes of its own. This is the message a failed listing actually produces.
+func TestLogFormatEscapesAQuotedFieldsValue(t *testing.T) {
+	const documented = `{"level":"%(levelname)s","ts":"%(created)s","logger":"%(name)s","msg":"%(message)s"}`
+
+	format, err := parseLogFormat(documented)
+	if err != nil {
+		t.Fatalf("parseLogFormat returned %v", err)
+	}
+
+	message := "Error listing pods in namespace \"default\": a \\, a\nnewline and a \x01"
+	line := format.render(levelError, message, at)
+
+	var got map[string]string
+	if err := json.Unmarshal([]byte(line), &got); err != nil {
+		t.Fatalf("the rendered line is not JSON: %v\nline: %s", err, line)
+	}
+	if got["msg"] != message {
+		t.Errorf("msg = %q, want the message unchanged: %q", got["msg"], message)
+	}
+}
+
+// Escaping belongs to the quotes the format wrote, not to the message. A field
+// the format did not put in quotes is written through verbatim, which is what
+// keeps a plain text line reading like one.
+func TestLogFormatEscapesOnlyWhatTheFormatQuoted(t *testing.T) {
+	const message = `namespace "default" \ here`
+
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{
+			name:   "the default format quotes nothing",
+			format: defaultLogFormat,
+			want:   `2026-08-24 13:56:40 ERROR: namespace "default" \ here`,
+		},
+		{
+			name:   "an opening quote alone is not a quoted field",
+			format: `msg="%(message)s`,
+			want:   `msg="namespace "default" \ here`,
+		},
+		{
+			name:   "a closing quote alone is not either",
+			format: `msg=%(message)s"`,
+			want:   `msg=namespace "default" \ here"`,
+		},
+		{
+			name:   "a quote on both sides is",
+			format: `msg="%(message)s"`,
+			want:   `msg="namespace \"default\" \\ here"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			format, err := parseLogFormat(tt.format)
+			if err != nil {
+				t.Fatalf("parseLogFormat(%q) returned %v", tt.format, err)
+			}
+
+			if got := format.render(levelError, message, at); got != tt.want {
+				t.Errorf("render() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 // A format that cannot be rendered is refused where it is written down, not
 // silently turned into blank lines at run time.
 func TestParseLogFormatRefusesAFormatItCannotRender(t *testing.T) {

--- a/pkg/janitor/logging_test.go
+++ b/pkg/janitor/logging_test.go
@@ -141,11 +141,14 @@ func TestLogFormatEscapesAQuotedFieldsValue(t *testing.T) {
 	}
 }
 
-// Escaping belongs to the quotes the format wrote, not to the message. A field
-// the format did not put in quotes is written through verbatim, which is what
-// keeps a plain text line reading like one.
-func TestLogFormatEscapesOnlyWhatTheFormatQuoted(t *testing.T) {
+// Escaping follows the quotes the format itself wrote: a field that falls
+// inside an open string is escaped so it stays inside it, and a field outside
+// one is written through, which is what keeps a plain text line reading like
+// one. Where the field sits within the string does not matter — only that it is
+// in one.
+func TestLogFormatEscapesWhatFallsInsideAString(t *testing.T) {
 	const message = `namespace "default" \ here`
+	const escaped = `namespace \"default\" \\ here`
 
 	tests := []struct {
 		name   string
@@ -153,24 +156,44 @@ func TestLogFormatEscapesOnlyWhatTheFormatQuoted(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "the default format quotes nothing",
+			name:   "the default format opens no string",
 			format: defaultLogFormat,
-			want:   `2026-08-24 13:56:40 ERROR: namespace "default" \ here`,
+			want:   `2026-08-24 13:56:40 ERROR: ` + message,
 		},
 		{
-			name:   "an opening quote alone is not a quoted field",
-			format: `msg="%(message)s`,
-			want:   `msg="namespace "default" \ here`,
-		},
-		{
-			name:   "a closing quote alone is not either",
-			format: `msg=%(message)s"`,
-			want:   `msg=namespace "default" \ here"`,
-		},
-		{
-			name:   "a quote on both sides is",
+			name:   "a field inside a string is escaped",
 			format: `msg="%(message)s"`,
-			want:   `msg="namespace \"default\" \\ here"`,
+			want:   `msg="` + escaped + `"`,
+		},
+		{
+			// The field does not have to touch the quotes to be inside them.
+			// Rendering it raw here would end the string early.
+			name:   "a field further inside a string is escaped too",
+			format: `{"msg":"deleting %(message)s now"}`,
+			want:   `{"msg":"deleting ` + escaped + ` now"}`,
+		},
+		{
+			// Both fields sit in one string, though the text between them is
+			// neither preceded nor followed by a quote.
+			name:   "every field in one string is escaped",
+			format: `{"msg":"%(levelname)s %(message)s"}`,
+			want:   `{"msg":"ERROR ` + escaped + `"}`,
+		},
+		{
+			name:   "an unterminated string still holds the field",
+			format: `msg="%(message)s`,
+			want:   `msg="` + escaped,
+		},
+		{
+			name:   "a field after the string closed is written through",
+			format: `{"a":"x"} %(message)s`,
+			want:   `{"a":"x"} ` + message,
+		},
+		{
+			// A quote the format escaped does not open a string.
+			name:   "an escaped quote opens nothing",
+			format: `he said \" %(message)s`,
+			want:   `he said \" ` + message,
 		},
 	}
 
@@ -183,6 +206,40 @@ func TestLogFormatEscapesOnlyWhatTheFormatQuoted(t *testing.T) {
 
 			if got := format.render(levelError, message, at); got != tt.want {
 				t.Errorf("render() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The README promises that a format building JSON keeps producing JSON. That
+// has to hold for a format an operator wrote, not only for the one the README
+// prints, so these are JSON formats that place their fields differently.
+func TestLogFormatKeepsAnyJSONFormatParseable(t *testing.T) {
+	message := "listing pods in namespace \"default\": C:\\temp\\report\nfailed"
+
+	formats := []string{
+		documentedJSONFormat,
+		`{"msg":"prefix %(message)s"}`,
+		`{"msg":"%(message)s suffix"}`,
+		`{"msg":"%(levelname)s %(message)s"}`,
+		`{"level":"%(levelname)s","msg":"deleting %(message)s now"}`,
+	}
+
+	for _, f := range formats {
+		t.Run(f, func(t *testing.T) {
+			format, err := parseLogFormat(f)
+			if err != nil {
+				t.Fatalf("parseLogFormat returned %v", err)
+			}
+
+			line := format.render(levelError, message, at)
+
+			var got map[string]string
+			if err := json.Unmarshal([]byte(line), &got); err != nil {
+				t.Fatalf("the rendered line is not JSON: %v\nline: %s", err, line)
+			}
+			if !strings.Contains(got["msg"], message) {
+				t.Errorf("msg = %q, want it to carry the message unchanged: %q", got["msg"], message)
 			}
 		})
 	}

--- a/pkg/janitor/rules_test.go
+++ b/pkg/janitor/rules_test.go
@@ -1,7 +1,6 @@
 package janitor
 
 import (
-	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -173,21 +172,10 @@ rules:
   jmespath: "metadata.labels.environment == 'test'"
   ttl: "24h"
 `
-	tmpfile, err := os.CreateTemp("", "rules*.yaml")
-	if err != nil {
-		t.Fatalf("Failed to create temp file: %v", err)
-	}
-	defer os.Remove(tmpfile.Name())
-
-	if _, err := tmpfile.Write([]byte(content)); err != nil {
-		t.Fatalf("Failed to write to temp file: %v", err)
-	}
-	if err := tmpfile.Close(); err != nil {
-		t.Fatalf("Failed to close temp file: %v", err)
-	}
+	path := writeRulesFile(t, content)
 
 	// Test loading rules
-	rules, err := LoadRules(tmpfile.Name())
+	rules, err := LoadRules(path)
 	if err != nil {
 		t.Fatalf("LoadRules() error = %v", err)
 	}

--- a/pkg/janitor/selector_test.go
+++ b/pkg/janitor/selector_test.go
@@ -19,7 +19,7 @@ func refs(listings []listing) []string {
 }
 
 func selectorFor(configure func(*Config)) *selector {
-	cfg := NewConfig()
+	cfg := newConfig()
 	cfg.ExcludeResources = nil
 	cfg.ExcludeNamespaces = nil
 	if configure != nil {


### PR DESCRIPTION
Implements candidate 2 from the architecture review: one call builds a valid Config. Two follow-on commits fall out of it — the log format the Config carries now actually does something, and the docs describe the options that exist.

## Build the Config in one call

Construction was six calls in a required order — `NewConfig`, `AddFlags`, `flag.Parse`, `ParseStringFlags`, `Validate`, `LoadRules`. Nothing enforced the order, and skipping `ParseStringFlags` silently reverted every list flag to its default. Defaults were written down three times, and the copy in `constants.go` had drifted (`events,controllerrevisions` against the real `events,controllerrevisions,endpoints`).

```go
LoadConfig(args []string, env func(string) string) (*Config, error)
```

- The four shadow string fields and `ParseStringFlags` are gone. A `stringList` `flag.Value` splits straight into the slice it sets, so a parsed FlagSet is a finished Config.
- The FlagSet is private, replacing the `flag.CommandLine` global.
- Defaults come from `newConfig` alone. The environment folds into those fields before the flags register, so usage prints the value a run would actually use, and flag-beats-env-beats-default falls out of construction order.
- `RESOURCE_CONTEXT_HOOK` resolves here too, so `main` no longer finishes the Config after Load returns, and an unknown hook name fails on the same path as an unreadable rules file.
- `Validate` and `LoadRules` are private; the dead `WebhookURL` field is deleted.

`env` is taken as an argument, so the suite no longer reads ambient variables — it previously failed on a machine that exported `INCLUDE_RESOURCES`.

## Make --log-format work

The flag was parsed, stored and never read: every line came out of `log.Printf` in whatever shape the standard logger chose. A user could set it, see no effect, and have no way to tell it was inert.

A format is now compiled once from the Python-style template the README documents, and every line goes through it. The fields are `%(asctime)s`, `%(created)s`, `%(levelname)s`, `%(name)s` and `%(message)s`, with `%%` for a literal percent. A format naming anything else is refused when the configuration loads:

```
Invalid configuration: log format has unknown placeholder %(nope)s,
want one of %(asctime)s, %(created)s, %(levelname)s, %(message)s, %(name)s
```

The Logger also decides which lines are written — debug lines only when debug is on, info lines unless the run is quiet, warnings and errors always — so callers no longer check either flag themselves.

### Behaviour changes

- Dry-run announcements are `INFO`, so `--quiet` hides them.
- Per-PVC context findings are `DEBUG`; they were printed unconditionally at one line per claim.
- Timestamps read `2026-08-24 13:56:40` rather than `2026/08/24 13:56:40`, and every line carries its level.
- `--debug` no longer adds file and line numbers, which came from the standard logger's flags.

## Docs

`--resource-context-hook` was documented as a flag with the example value `hooks.RandomDice`. No such flag exists and no hook answers to that name — the feature runs from `RESOURCE_CONTEXT_HOOK`, and the one built-in hook is `random_dice`. `--debug` and `--quiet` are described in terms of the levels they now control; `--quiet` had claimed to keep deletion logs, which it has not done for as long as those lines have gone through the info path.

## Review fixes

Three review rounds landed on top of the work above.

**Log lines that build JSON stay JSON.** The first version of the escaping rule only escaped a field flush between two quotes, so `{"msg":"prefix %(message)s"}` and `{"msg":"%(levelname)s %(message)s"}` escaped nothing. That produced lines that would not parse, and worse, lines that would: a Windows path rendered as `{"msg":"deleting C:\temp\report"}`, valid JSON carrying a tab and a carriage return where `\t` and `\r` had been, with nothing downstream to signal the message was mangled. The parser now tracks whether the format has an open quote where it reaches a placeholder, honouring a quote the format escaped.

**`--debug` and `--quiet` were independent gates**, so both together wrote DEBUG and dropped INFO. The levels are ordered and the Configuration resolves to one threshold; `--debug` wins.

**`-help` is answerable whatever the environment holds.** `RESOURCE_CONTEXT_HOOK` naming nothing used to turn `-h` into an exit code, because the hook resolved before the arguments were parsed. It now resolves after. `LoadConfig` writes nothing and returns every failure, so a bad flag is reported once rather than twice by two different printers, and usage goes to stdout.

**The Janitor is handed its Logger** rather than building a second one onto stderr, so one process has one Logger and a test can read back what a run said.

Cleanup from the same rounds: `LoadConfig` and `Usage` share one flag-set constructor, so usage cannot describe a run the binary would not perform; the compiled format keeps one list of placeholders rather than a parallel bool slice; and the escaping path no longer reaches for `fmt`, which had been moving every rendered line's builder to the heap even for formats that quote nothing.

## Verification

Each commit builds and passes the suite on its own, checked in a separate worktree. Package coverage 75.3% -> 82.9%.

Mutation-tested throughout: 11 mutations against the config path, 12 against the log format, and 9 against the quote scanner and escaping table, all caught bar two provably equivalent ones (`\t` and `\r` are already covered by the control-character branch). Two config mutations survived: `RULES_FILE` bypassing the empty-means-unset guard, which is unobservable since the default is empty, and the default slices being shared rather than cloned, which now has a test.

Checked against the built binary: `-h` exits 0 with an empty stderr, and still does with a broken `RESOURCE_CONTEXT_HOOK`; a bad flag exits 1 with one message; usage prints the defaults the environment actually gives; and a JSON-formatted run whose message carries a quote, a backslash and a Windows path round-trips through a parser unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
