### PR TITLE
Let Connect name the credentials it used

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -122,8 +122,11 @@ _Avoid_: Logger (the name of the thing, not of the module), output, printer
 
 **Connect**:
 The module that resolves the ambient credentials and returns the Cluster they
-grant. A run is handed a Cluster and never builds one, so the whole of a run can
-be exercised against fakes.
+grant, along with the name of the credentials it used. It is the only thing that
+knows the order the credentials are looked for in, so nothing else works that
+order out again in order to say which ones a run is working through. A run is
+handed a Cluster and never builds one, so the whole of a run can be exercised
+against fakes.
 _Avoid_: Client factory, bootstrap, initialise
 
 **Load**:

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ in. When set, delete notifications are prefixed with `[name]`, in both
 the Kubernetes event and the webhook payload, so notifications from
 several clusters can be told apart.
 
+`KUBECONFIG`
+
+: Optional: environment variable naming the kubeconfig a run connects
+with when it is not running as a pod. A run inside a cluster uses its
+service account and ignores this. Outside one, a run falls back to
+`~/.kube/config` when this is unset. A run says at startup which
+credentials it connected with.
+
 `RESOURCE_CONTEXT_HOOK`
 
 : Optional: environment variable naming a built-in hook that

--- a/cmd/kube-janitor/main.go
+++ b/cmd/kube-janitor/main.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/dschaaff/kube-janitor/pkg/janitor"
@@ -43,26 +42,13 @@ func main() {
 		logger.Infof("Running in dry-run mode")
 	}
 
-	// Check for KUBECONFIG environment variable
-	if os.Getenv("KUBECONFIG") == "" {
-		homeDir, err := os.UserHomeDir()
-		if err == nil {
-			defaultKubeconfig := filepath.Join(homeDir, ".kube", "config")
-			if _, err := os.Stat(defaultKubeconfig); err == nil {
-				logger.Infof("KUBECONFIG not set, using default: %s", defaultKubeconfig)
-			} else {
-				logger.Warnf("KUBECONFIG not set and default config not found at %s", defaultKubeconfig)
-			}
-		}
-	} else {
-		logger.Infof("Using KUBECONFIG from environment: %s", os.Getenv("KUBECONFIG"))
-	}
-
-	cluster, err := janitor.Connect()
+	cluster, credentials, err := janitor.Connect()
 	if err != nil {
 		logger.Errorf("Failed to connect to cluster: %v", err)
 		os.Exit(1)
 	}
+
+	logger.Infof("Connected using %s", credentials)
 
 	j := janitor.New(config, cluster, logger, janitor.NewNotifier(config))
 

--- a/pkg/janitor/cluster.go
+++ b/pkg/janitor/cluster.go
@@ -20,46 +20,75 @@ type Cluster struct {
 	Dynamic dynamic.Interface
 }
 
+// inClusterCredentials names the credentials a run gets for being a pod.
+const inClusterCredentials = "the in-cluster service account"
+
 // Connect resolves the ambient credentials and returns the connections they
-// grant: the in-cluster service account when running as a pod, and the
-// kubeconfig otherwise. Both clients share one resolved configuration.
-func Connect() (Cluster, error) {
-	config, err := restConfig()
+// grant, together with the name of the credentials it used: the in-cluster
+// service account when running as a pod, and the kubeconfig otherwise. Both
+// clients share one resolved configuration.
+//
+// The name is what a run says it connected with. Connect is the only thing
+// that knows the order the credentials are looked for in, so nothing else has
+// to work that order out again to talk about it — and nothing else can get it
+// wrong.
+func Connect() (Cluster, string, error) {
+	config, credentials, err := restConfig()
 	if err != nil {
-		return Cluster{}, err
+		return Cluster{}, "", err
 	}
 
 	typed, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return Cluster{}, fmt.Errorf("failed to create client: %v", err)
+		return Cluster{}, "", fmt.Errorf("failed to create client: %v", err)
 	}
 
 	dyn, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return Cluster{}, fmt.Errorf("failed to create dynamic client: %v", err)
+		return Cluster{}, "", fmt.Errorf("failed to create dynamic client: %v", err)
 	}
 
-	return Cluster{Typed: typed, Dynamic: dyn}, nil
+	return Cluster{Typed: typed, Dynamic: dyn}, credentials, nil
 }
 
 // restConfig prefers the in-cluster service account, and falls back to the
 // kubeconfig named by KUBECONFIG or found in the user's home directory.
-func restConfig() (*rest.Config, error) {
+func restConfig() (*rest.Config, string, error) {
 	if config, err := rest.InClusterConfig(); err == nil {
-		return config, nil
+		return config, inClusterCredentials, nil
 	}
 
-	kubeconfigPath := os.Getenv("KUBECONFIG")
-	if kubeconfigPath == "" {
-		if homeDir, err := os.UserHomeDir(); err == nil {
-			kubeconfigPath = filepath.Join(homeDir, ".kube", "config")
-		}
-	}
+	// A home directory that cannot be resolved is not itself the failure worth
+	// reporting: it just leaves nowhere to look, which the empty path below
+	// turns into the one error a run gets.
+	home, _ := os.UserHomeDir()
+	path, credentials := kubeconfig(os.Getenv("KUBECONFIG"), home)
 
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	config, err := clientcmd.BuildConfigFromFlags("", path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create config: %v (try setting KUBECONFIG environment variable)", err)
+		return nil, "", fmt.Errorf("failed to create config: %v (try setting KUBECONFIG environment variable)", err)
 	}
 
-	return config, nil
+	return config, credentials, nil
+}
+
+// kubeconfig names the file a run reads its credentials from when it is not
+// running as a pod, and words what it found for the run to report.
+//
+// An empty home leaves both empty rather than guessing at a path: a run with
+// nowhere to look should fail saying so, not saying that a file it was never
+// going to find is missing. Nothing reports the empty wording, because an
+// empty path never builds a configuration to report about.
+func kubeconfig(fromEnv, home string) (path, credentials string) {
+	if fromEnv != "" {
+		return fromEnv, "kubeconfig " + fromEnv + ", named by KUBECONFIG"
+	}
+
+	if home == "" {
+		return "", ""
+	}
+
+	path = filepath.Join(home, ".kube", "config")
+
+	return path, "kubeconfig " + path
 }

--- a/pkg/janitor/cluster_test.go
+++ b/pkg/janitor/cluster_test.go
@@ -1,0 +1,166 @@
+package janitor
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// aKubeconfig writes a kubeconfig naming one unreachable server and returns its
+// path. Nothing dials it: building the connections only has to parse the file.
+func aKubeconfig(t *testing.T) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "config")
+	const content = `apiVersion: v1
+kind: Config
+current-context: test
+clusters:
+- name: test
+  cluster:
+    server: https://kubernetes.invalid
+contexts:
+- name: test
+  context:
+    cluster: test
+    user: test
+users:
+- name: test
+  user:
+    token: not-a-real-token
+`
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+
+	return path
+}
+
+// outsideACluster makes the in-cluster service account unavailable, so a case
+// about the kubeconfig holds even when the tests themselves run in a pod.
+func outsideACluster(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", "")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "")
+}
+
+func TestConnectNamesTheCredentialsItUsed(t *testing.T) {
+	outsideACluster(t)
+
+	path := aKubeconfig(t)
+	t.Setenv("KUBECONFIG", path)
+
+	cluster, credentials, err := Connect()
+	if err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+
+	if cluster.Typed == nil || cluster.Dynamic == nil {
+		t.Errorf("connected without both clients: %+v", cluster)
+	}
+
+	if !strings.Contains(credentials, path) || !strings.Contains(credentials, "KUBECONFIG") {
+		t.Errorf("credentials %q name neither %q nor KUBECONFIG", credentials, path)
+	}
+}
+
+func TestConnectReportsCredentialsItCannotResolve(t *testing.T) {
+	outsideACluster(t)
+
+	t.Setenv("KUBECONFIG", filepath.Join(t.TempDir(), "absent"))
+
+	if _, _, err := Connect(); err == nil {
+		t.Fatal("connected with a kubeconfig that is not there")
+	} else if !strings.Contains(err.Error(), "KUBECONFIG") {
+		t.Errorf("error %q does not say which variable to set", err)
+	}
+}
+
+// nowhereToLook empties every variable a home directory is resolved from, so
+// the run has no kubeconfig to fall back to on any platform.
+func nowhereToLook(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("KUBECONFIG", "")
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+}
+
+func TestConnectReportsHavingNowhereToLook(t *testing.T) {
+	outsideACluster(t)
+	nowhereToLook(t)
+
+	_, credentials, err := Connect()
+	if err == nil {
+		t.Fatal("connected with nowhere to look for credentials")
+	}
+
+	if !strings.Contains(err.Error(), "KUBECONFIG") {
+		t.Errorf("error %q does not say which variable to set", err)
+	}
+
+	// The empty wording kubeconfig leaves behind must never reach a Log line:
+	// a run that did not connect has nothing to say it connected with.
+	if credentials != "" {
+		t.Errorf("credentials %q reported for a connection that was never made", credentials)
+	}
+}
+
+func TestKubeconfigResolution(t *testing.T) {
+	tests := []struct {
+		name        string
+		fromEnv     string
+		home        string
+		wantPath    string
+		credentials []string
+	}{
+		{
+			name:        "KUBECONFIG names one",
+			fromEnv:     "/etc/kube/config",
+			home:        "/home/janitor",
+			wantPath:    "/etc/kube/config",
+			credentials: []string{"/etc/kube/config", "KUBECONFIG"},
+		},
+		{
+			name:        "the home directory holds the only one",
+			home:        "/home/janitor",
+			wantPath:    "/home/janitor/.kube/config",
+			credentials: []string{"/home/janitor/.kube/config"},
+		},
+		{
+			name:     "there is nowhere to look",
+			wantPath: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, credentials := kubeconfig(tt.fromEnv, tt.home)
+
+			if path != tt.wantPath {
+				t.Errorf("path = %q, want %q", path, tt.wantPath)
+			}
+
+			for _, want := range tt.credentials {
+				if !strings.Contains(credentials, want) {
+					t.Errorf("credentials %q do not name %q", credentials, want)
+				}
+			}
+
+			if tt.wantPath == "" && credentials != "" {
+				t.Errorf("credentials %q worded for a path that was never found", credentials)
+			}
+		})
+	}
+}
+
+func TestKubeconfigFromTheHomeDirectoryDoesNotClaimKUBECONFIG(t *testing.T) {
+	_, credentials := kubeconfig("", "/home/janitor")
+
+	if strings.Contains(credentials, "KUBECONFIG") {
+		t.Errorf("credentials %q credit KUBECONFIG, which named nothing", credentials)
+	}
+}


### PR DESCRIPTION
## The bug

Every run inside the shipped Deployment logged a warning and then connected fine:

```
WARNING: KUBECONFIG not set and default config not found at /root/.kube/config
```

`main.go` was working credential resolution out a second time purely to log about it, and its copy did not know the in-cluster service account exists. `Connect` knew, and said nothing.

## The change

`Connect` returns the name of the credentials it used alongside the `Cluster` they grant. `main.go` reports what it is told:

```
INFO: Connected using kubeconfig /home/janitor/.kube/config, named by KUBECONFIG
```

That removes 14 lines, one `os.Stat` and the `path/filepath` import from `main.go`, and leaves one module knowing the order the credentials are looked for in.

Choosing the kubeconfig moves into a private function taking the `KUBECONFIG` value and the home directory as plain strings, so the resolution order is testable without touching the process environment. `os.UserHomeDir` stays at the edge, because goreleaser builds Windows binaries where home is not `$HOME`.

A run with nowhere to look words nothing: it fails before it has anything to say it connected with.

`CONTEXT.md`'s **Connect** entry records that it names the credentials and owns the resolution order. `README.md` documents `KUBECONFIG` for the first time.

## Verification

`gofmt`, `go vet` and `go test -race ./...` are clean, and the built binary was run both ways to confirm the log output. Each mutation below was applied and killed by the named test:

| Mutation | Test that caught it |
| --- | --- |
| Check home before `KUBECONFIG` | `TestKubeconfigResolution/KUBECONFIG_names_one` |
| Guess a path when there is no home | `TestKubeconfigResolution/there_is_nowhere_to_look` |
| Credit `KUBECONFIG` for the home default | `TestKubeconfigFromTheHomeDirectoryDoesNotClaimKUBECONFIG` |
| Return empty credentials from `Connect` | `TestConnectNamesTheCredentialsItUsed` |
| Drop the `KUBECONFIG` hint from the failure | `TestConnectReportsCredentialsItCannotResolve` |
| Report credentials for a failed connection | `TestConnectReportsHavingNowhereToLook` |

The in-cluster branch is not covered. Faking it needs `rest.InClusterConfig` injected, which would be a seam whose only adapter is a test fake, for three unchanged lines whose output is a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)